### PR TITLE
Separate tspec states #29

### DIFF
--- a/contracts/tests/golos.worker_tests.cpp
+++ b/contracts/tests/golos.worker_tests.cpp
@@ -41,6 +41,7 @@ enum tspec_state_t {
     STATE_WORK,
     STATE_DELEGATES_REVIEW,
     STATE_PAYMENT,
+    STATE_PAYMENT_COMPLETE,
     STATE_CLOSED
 };
 
@@ -778,7 +779,8 @@ try
         ASSERT_SUCCESS(worker->push_action(worker_account, N(withdraw), mvo()
             ("tspec_app_id", tspec_id)));
 
-        BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
+        BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_PAYMENT_COMPLETE);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_CREATE);
 
         auto worker_balance = token->get_account(worker_account, "3,APP");
         REQUIRE_MATCHING_OBJECT(worker_balance, mvo()("balance", "15.000 APP"));
@@ -839,7 +841,8 @@ try
             ("tspec_app_id", 0))); // addpropos2 uses available_primary_key
     }
 
-    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(0), STATE_CLOSED); // addpropos2 uses available_primary_key
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(0), STATE_PAYMENT_COMPLETE); // addpropos2 uses available_primary_key
+    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_CREATE);
 
    auto worker_balance = token->get_account(worker_account, "3,APP");
    REQUIRE_MATCHING_OBJECT(worker_balance, mvo()("balance", "15.000 APP"));
@@ -869,10 +872,11 @@ try
         ("tspec_app_id", tspec_id)
         ("initiator", worker_account)));
 
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
+    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_APP);
+
     BOOST_REQUIRE_EQUAL(worker->push_action(worker_account, N(withdraw), mvo()
         ("tspec_app_id", tspec_id)), wasm_assert_msg("invalid state for withdraw"));
-
-    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
 
     // if proposal is closed deposit should be refunded to the application fund
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], app_fund_supply.to_string());
@@ -905,10 +909,12 @@ try
         ("tspec_app_id", tspec_id)
         ("initiator", tspec_author)));
 
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
+    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_APP);
+
     BOOST_REQUIRE_EQUAL(worker->push_action(worker_account, N(withdraw), mvo()
         ("tspec_app_id", tspec_id)), wasm_assert_msg("invalid state for withdraw"));
 
-    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
     // if proposal is closed deposit should be refunded to the application fund
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], app_fund_supply.to_string());
 
@@ -947,10 +953,12 @@ try
             ("comment", mvo()("text", "Lorem Ipsum"))));
     }
 
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
+    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_APP);
+
     BOOST_REQUIRE_EQUAL(worker->push_action(worker_account, N(withdraw), mvo()
         ("tspec_app_id", tspec_id)), wasm_assert_msg("invalid state for withdraw"));
 
-    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
     // if proposal is closed deposit should be refunded to the application fund
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], app_fund_supply.to_string());
 

--- a/contracts/tests/golos.worker_tests.cpp
+++ b/contracts/tests/golos.worker_tests.cpp
@@ -30,9 +30,14 @@ constexpr const char *long_text = "Lorem ipsum dolor sit amet, amet sint accusam
 constexpr size_t delegates_count = 21;
 constexpr size_t delegates_51 = delegates_count / 2 + 1;
 
-enum state_t {
+enum proposal_state_t {
     STATE_TSPEC_APP = 1,
-    STATE_TSPEC_CREATE,
+    STATE_TSPEC_CREATE
+};
+
+enum tspec_state_t {
+    STATE_CREATED = 1,
+    STATE_APPROVED,
     STATE_WORK,
     STATE_DELEGATES_REVIEW,
     STATE_PAYMENT,
@@ -163,21 +168,26 @@ class worker_contract : public base_contract
     {
     }
 
-    fc::variant get_proposal(name scope, uint64_t id) {
-        return base_contract::get_table_row(N(proposals), "proposal_t", scope, id);
+    fc::variant get_proposal(uint64_t id) {
+        return base_contract::get_table_row(N(proposals), "proposal_t", worker_code_account, id);
     }
 
-    uint8_t get_proposal_state(name scope, uint64_t proposal_id) {
-        auto proposal = get_proposal(scope, proposal_id);
+    uint8_t get_proposal_state(uint64_t proposal_id) {
+        auto proposal = get_proposal(proposal_id);
         return proposal["state"].as_int64();
+    }
+
+    uint8_t get_tspec_state(uint64_t tspec_app_id) {
+        auto tspec = get_tspec(tspec_app_id);
+        return tspec["state"].as_int64();
     }
 
     fc::variant get_state(name scope) {
         return base_contract::get_table_row(N(state), "state_t", scope, 0);
     }
 
-    fc::variant get_tspec(name scope, uint64_t id) {
-        return base_contract::get_table_row(N(tspecs), "tspec_app_t", scope, id);
+    fc::variant get_tspec(uint64_t id) {
+        return base_contract::get_table_row(N(tspecs), "tspec_app_t", worker_code_account, id);
     }
 
     fc::variant get_proposal_comment(name scope, uint64_t id) {
@@ -261,8 +271,7 @@ class golos_worker_tester : public tester
         BOOST_REQUIRE_EQUAL(fund["quantity"], app_fund_supply.to_string());
     }
 
-    void add_proposal(uint64_t proposal_id, const name& proposal_author, const name& tspec_author, const name& worker_account) {
-        const uint64_t tspec_app_id = proposal_id * 100;
+    void add_proposal(uint64_t proposal_id, const name& proposal_author, uint64_t tspec_app_id, const name& tspec_author, const name& worker_account) {
         const uint64_t other_tspec_app_id = tspec_app_id + 1;
         uint64_t comment_id = proposal_id  * 100;
 
@@ -274,7 +283,7 @@ class golos_worker_tester : public tester
 
         produce_blocks(1);
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), 1);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), 1);
         
         BOOST_TEST_MESSAGE("adding tspec");
         ASSERT_SUCCESS(worker->push_action(tspec_author, N(addtspec), mvo()
@@ -290,7 +299,7 @@ class golos_worker_tester : public tester
                 ("payments_interval", 1))
             ("tspec_text", "Technical specification #1")));
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_TSPEC_APP);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_APP);
 
         ASSERT_SUCCESS(worker->push_action(tspec_author, N(addtspec), mvo()
             ("proposal_id", proposal_id)
@@ -305,7 +314,7 @@ class golos_worker_tester : public tester
                 ("payments_interval", 1))
             ("tspec_text", "Technical specification #2")));
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_TSPEC_APP);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_APP);
 
         // vote for the 0 technical specification application
         for (size_t i = 0; i < delegates_51; i++)
@@ -319,9 +328,10 @@ class golos_worker_tester : public tester
                 ("comment", mvo()("text", "Lorem Ipsum"))));
         }
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_TSPEC_CREATE);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_CREATE);
         // if technical specification application was upvoted, `proposal_deposit` should be deposited from the application fund
-        BOOST_REQUIRE_EQUAL(worker->get_proposal(worker_code_account, proposal_id)["deposit"], proposal_deposit.to_string());
+        BOOST_REQUIRE_EQUAL(worker->get_proposal(proposal_id)["deposit"], proposal_deposit.to_string());
+        BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_app_id), STATE_APPROVED);
 
         /* ok,technical specification application has been choosen,
         now technical specification application author should publish
@@ -338,7 +348,7 @@ class golos_worker_tester : public tester
                 ("payments_interval", 1))
             ("tspec_text", long_text)), wasm_assert_msg("cost can't be modified"));
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_TSPEC_CREATE);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_CREATE);
 
         ASSERT_SUCCESS(worker->push_action(tspec_author, N(edittspec), mvo()
             ("tspec_app_id", tspec_app_id)
@@ -351,13 +361,13 @@ class golos_worker_tester : public tester
                 ("payments_interval", 1))
             ("tspec_text", long_text)));
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_TSPEC_CREATE);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_CREATE);
 
         ASSERT_SUCCESS(worker->push_action(tspec_author, N(startwork), mvo()
-            ("proposal_id", proposal_id)
+            ("tspec_app_id", tspec_app_id)
             ("worker", worker_account)));
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_WORK);
+        BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_app_id), STATE_WORK);
 
         for (int i = 0; i < 5; i++) {
             ASSERT_SUCCESS(worker->push_action(worker_account, N(poststatus), mvo()
@@ -389,7 +399,7 @@ try
             ("title", "Proposal #1")
             ("description", "Description #1")));
         return;
-        auto proposal_row = worker->get_proposal(worker_code_account, proposal_id);
+        auto proposal_row = worker->get_proposal(proposal_id);
         BOOST_REQUIRE_EQUAL(proposal_row["state"], STATE_TSPEC_APP);
         BOOST_REQUIRE_EQUAL(proposal_row["title"], "Proposal #1");
         BOOST_REQUIRE_EQUAL(proposal_row["description"], "Description #1");
@@ -405,13 +415,13 @@ try
             ("title", "")
             ("description", "")), wasm_assert_msg("invalid arguments"));
 
-        proposal_row = worker->get_proposal(worker_code_account, proposal_id);
+        proposal_row = worker->get_proposal(proposal_id);
         BOOST_REQUIRE_EQUAL(proposal_row["title"], "New Proposal #1");
 
         ASSERT_SUCCESS(worker->push_action(author_account, N(delpropos), mvo()
             ("proposal_id", proposal_id)));
 
-        proposal_row = worker->get_proposal(worker_code_account, proposal_id);
+        proposal_row = worker->get_proposal(proposal_id);
         BOOST_REQUIRE(proposal_row.is_null());
     }
 }
@@ -499,7 +509,7 @@ try
     ASSERT_SUCCESS(worker->push_action(members[0], N(delpropos), mvo()
         ("proposal_id", proposal_id)));
 
-    BOOST_REQUIRE(worker->get_proposal(worker_code_account, proposal_id).is_null());
+    BOOST_REQUIRE(worker->get_proposal(proposal_id).is_null());
 }
 FC_LOG_AND_RETHROW()
 
@@ -593,7 +603,7 @@ try
             ("description", "Description #1"))
         );
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_TSPEC_APP);
+        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_APP);
 
         for (uint64_t j = 0; j < 1; j++) {
             const uint64_t tspec_app_id = 100 * i + j;
@@ -613,7 +623,7 @@ try
 
             ASSERT_SUCCESS(worker->push_action(tspec_author, N(addtspec), tspec_app));
 
-            auto tspec_row = worker->get_tspec(worker_code_account, tspec_app_id);
+            auto tspec_row = worker->get_tspec(tspec_app_id);
             BOOST_REQUIRE_EQUAL(tspec_row["id"].as_int64(), tspec_app_id);
             REQUIRE_MATCHING_OBJECT(tspec_row["data"], tspec_app["tspec"]);
 
@@ -628,7 +638,7 @@ try
                     ("payments_interval", 2))
                 ("tspec_text", "Technical specification")));
 
-            tspec_row = worker->get_tspec(worker_code_account, tspec_app_id);
+            tspec_row = worker->get_tspec(tspec_app_id);
             BOOST_REQUIRE_EQUAL(tspec_row["data"]["specification_cost"].as_string(), "2.000 APP");
             BOOST_REQUIRE_EQUAL(tspec_row["data"]["development_cost"].as_string(), "2.000 APP");
 
@@ -646,13 +656,13 @@ try
             ASSERT_SUCCESS(worker->push_action(tspec_author, N(deltspec), mvo()
                 ("tspec_app_id", tspec_app_id)));
 
-            BOOST_REQUIRE(worker->get_tspec(worker_code_account, tspec_app_id).is_null());
+            BOOST_REQUIRE(worker->get_tspec(tspec_app_id).is_null());
         }
 
         ASSERT_SUCCESS(worker->push_action(proposal_author, N(delpropos), mvo()
             ("proposal_id", proposal_id)));
 
-        BOOST_REQUIRE(worker->get_proposal(worker_code_account, proposal_id).is_null());
+        BOOST_REQUIRE(worker->get_proposal(proposal_id).is_null());
     }
 }
 FC_LOG_AND_RETHROW()
@@ -677,7 +687,7 @@ try
 
     BOOST_REQUIRE_EQUAL(worker->get_proposals_count(worker_code_account), 1);
 
-    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_TSPEC_APP);
+    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(proposal_id), STATE_TSPEC_APP);
 
     for (uint64_t j = 0; j < relative_rows_count; j++) {
         const uint64_t tspec_app_id = 100 + j;
@@ -725,13 +735,14 @@ try
     BOOST_TEST_MESSAGE("Testing: application_fund");
 
     for (uint64_t proposal_id = 0; proposal_id < 5; proposal_id++) {
+        uint64_t tspec_id = proposal_id * 100;
         uint64_t comment_id = proposal_id  * 100;
 
         const name& proposal_author = members[proposal_id * 3];
         const name& tspec_author = members[proposal_id * 3 + 1];
         const name& worker_account = members[proposal_id * 3 + 2];
 
-        add_proposal(proposal_id, proposal_author, tspec_author, worker_account);
+        add_proposal(proposal_id, proposal_author, tspec_id, tspec_author, worker_account);
 
         // revote for the proposal
         for (size_t i = 0; i < delegates.size(); i++)
@@ -745,29 +756,29 @@ try
         }
 
         ASSERT_SUCCESS(worker->push_action(tspec_author, N(acceptwork), mvo()
-            ("proposal_id", proposal_id)
+            ("tspec_app_id", tspec_id)
             ("comment_id", comment_id++)
             ("comment", mvo()
                 ("text", long_text))));
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_DELEGATES_REVIEW);
+        BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_DELEGATES_REVIEW);
 
         for (size_t i = 0; i < delegates.size(); i++) {
             const name &delegate = delegates[i];
             ASSERT_SUCCESS(worker->push_action(delegate, N(reviewwork), mvo()
-                ("proposal_id", proposal_id)
+                ("tspec_app_id", tspec_id)
                 ("reviewer", delegate.to_string())
                 ("status", (i + 1) % 2)
                 ("comment_id", comment_id++)
                 ("comment", mvo()("text", "Lorem Ipsum"))));
         }
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_PAYMENT);
+        BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_PAYMENT);
 
         ASSERT_SUCCESS(worker->push_action(worker_account, N(withdraw), mvo()
-            ("proposal_id", proposal_id)));
+            ("tspec_app_id", tspec_id)));
 
-        BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_CLOSED);
+        BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
 
         auto worker_balance = token->get_account(worker_account, "3,APP");
         REQUIRE_MATCHING_OBJECT(worker_balance, mvo()("balance", "15.000 APP"));
@@ -808,12 +819,12 @@ try
             ("text", long_text))
         ));
 
-    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_DELEGATES_REVIEW);
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(0), STATE_DELEGATES_REVIEW); // addpropos2 uses available_primary_key
 
     int i = 0;
     for (const auto &account : delegates) {
         ASSERT_SUCCESS(worker->push_action(account, N(reviewwork), mvo()
-            ("proposal_id", proposal_id)
+            ("tspec_app_id", 0) // addpropos2 uses available_primary_key
             ("reviewer", account.to_string())
             ("status", (i + 1) % 2)
             ("comment_id", 500 + i)
@@ -821,14 +832,14 @@ try
         i++;
     }
 
-    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_PAYMENT);
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(0), STATE_PAYMENT); // addpropos2 uses available_primary_key
 
     for (int i = 0; i < payments_count; i++) {
         ASSERT_SUCCESS(worker->push_action(worker_account, N(withdraw), mvo()
-            ("proposal_id", 1)));
+            ("tspec_app_id", 0))); // addpropos2 uses available_primary_key
     }
 
-    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_CLOSED);
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(0), STATE_CLOSED); // addpropos2 uses available_primary_key
 
    auto worker_balance = token->get_account(worker_account, "3,APP");
    REQUIRE_MATCHING_OBJECT(worker_balance, mvo()("balance", "15.000 APP"));
@@ -844,23 +855,24 @@ try
     BOOST_TEST_MESSAGE("Testing: cancel_work_by_worker");
 
     uint64_t proposal_id = 0;
+    uint64_t tspec_id = 0;
     const name& proposal_author = members[proposal_id * 3];
     const name& tspec_author = members[proposal_id * 3 + 1];
     const name& worker_account = members[proposal_id * 3 + 2];
 
-    add_proposal(proposal_id, proposal_author, tspec_author, worker_account);
+    add_proposal(proposal_id, proposal_author, tspec_id, tspec_author, worker_account);
 
     // the application fund quantity should be `propsal_deposit` less if proposal is in `STATE_TSPEC_CREATE`, `STATE_WORK`
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], (app_fund_supply - proposal_deposit).to_string());
 
     ASSERT_SUCCESS(worker->push_action(worker_account, N(cancelwork), mvo()
-        ("proposal_id", proposal_id)
+        ("tspec_app_id", tspec_id)
         ("initiator", worker_account)));
 
     BOOST_REQUIRE_EQUAL(worker->push_action(worker_account, N(withdraw), mvo()
-        ("proposal_id", proposal_id)), wasm_assert_msg("invalid state for withdraw"));
+        ("tspec_app_id", tspec_id)), wasm_assert_msg("invalid state for withdraw"));
 
-    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_CLOSED);
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
 
     // if proposal is closed deposit should be refunded to the application fund
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], app_fund_supply.to_string());
@@ -879,23 +891,24 @@ try
     BOOST_TEST_MESSAGE("Testing: cancel_work_by_tspec_author");
 
     uint64_t proposal_id = 0;
+    uint64_t tspec_id = 0;
     const name& proposal_author = members[proposal_id * 3];
     const name& tspec_author = members[proposal_id * 3 + 1];
     const name& worker_account = members[proposal_id * 3 + 2];
 
-    add_proposal(proposal_id, proposal_author, tspec_author, worker_account);
+    add_proposal(proposal_id, proposal_author, tspec_id, tspec_author, worker_account);
 
     // the application fund quantity should be `propsal_deposit` less if proposal is in `STATE_TSPEC_CREATE`, `STATE_WORK`
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], (app_fund_supply - proposal_deposit).to_string());
 
     ASSERT_SUCCESS(worker->push_action(tspec_author, N(cancelwork), mvo()
-        ("proposal_id", proposal_id)
+        ("tspec_app_id", tspec_id)
         ("initiator", tspec_author)));
 
     BOOST_REQUIRE_EQUAL(worker->push_action(worker_account, N(withdraw), mvo()
-        ("proposal_id", proposal_id)), wasm_assert_msg("invalid state for withdraw"));
+        ("tspec_app_id", tspec_id)), wasm_assert_msg("invalid state for withdraw"));
 
-    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_CLOSED);
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
     // if proposal is closed deposit should be refunded to the application fund
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], app_fund_supply.to_string());
 
@@ -913,12 +926,13 @@ try
     BOOST_TEST_MESSAGE("Testing: cancel_work_by_delegates");
 
     uint64_t proposal_id = 0;
+    uint64_t tspec_id = 0;
     uint64_t comment_id = 0;
     const name& proposal_author = members[proposal_id * 3];
     const name& tspec_author = members[proposal_id * 3 + 1];
     const name& worker_account = members[proposal_id * 3 + 2];
 
-    add_proposal(proposal_id, proposal_author, tspec_author, worker_account);
+    add_proposal(proposal_id, proposal_author, tspec_id, tspec_author, worker_account);
 
     // the application fund quantity should be `propsal_deposit` less if proposal is in `STATE_TSPEC_CREATE`, `STATE_WORK`
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], (app_fund_supply - proposal_deposit).to_string());
@@ -926,7 +940,7 @@ try
     for (size_t i = 0; i < delegates.size() * 3 / 4 + 1; i++) {
         const name &delegate = delegates[i];
         ASSERT_SUCCESS(worker->push_action(delegate, N(reviewwork), mvo()
-            ("proposal_id", proposal_id)
+            ("tspec_app_id", tspec_id)
             ("reviewer", delegate)
             ("status", 0)
             ("comment_id", comment_id++)
@@ -934,9 +948,9 @@ try
     }
 
     BOOST_REQUIRE_EQUAL(worker->push_action(worker_account, N(withdraw), mvo()
-        ("proposal_id", proposal_id)), wasm_assert_msg("invalid state for withdraw"));
+        ("tspec_app_id", tspec_id)), wasm_assert_msg("invalid state for withdraw"));
 
-    BOOST_REQUIRE_EQUAL(worker->get_proposal_state(worker_code_account, proposal_id), STATE_CLOSED);
+    BOOST_REQUIRE_EQUAL(worker->get_tspec_state(tspec_id), STATE_CLOSED);
     // if proposal is closed deposit should be refunded to the application fund
     BOOST_REQUIRE_EQUAL(worker->get_fund(worker_code_account, worker_code_account)["quantity"], app_fund_supply.to_string());
 


### PR DESCRIPTION
Resolve #29:
- Replaced `proposal_id` to `tspec_app_id` in actions.
- Review votes are binding to tspec, not proposal.
- Introduced closed state of tspec and good closed (payment complete) state. On first one setting, proposal state setting to APP (open).
- In tests removed `scope` parameter where it is contract's `_self` always.

TODOs for another issues:
- Clear approved-tspec_id of proposal when closing approved tspec
- Add separate closed states - closed by delegates, by author, etc. Add event for it.
- Move payment fields from proposal to tspec, and move `review_status` to tspec (https://github.com/GolosChain/golos.worker/issues/33)
- Refactor comments (https://github.com/GolosChain/golos.worker/issues/28)