### PR TITLE
Move work and payment fields from proposal to tspec #33

### DIFF
--- a/.buildkite/steps/deploy-test.sh
+++ b/.buildkite/steps/deploy-test.sh
@@ -15,7 +15,7 @@ docker-compose up -d
 
 # Run unit-tests
 sleep 10s
-docker run --network golos-tests_contracts-net -ti cyberway/golos.worker:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/golos.worker/unit_test -l message -r detailed && /opt/cyberway.contracts/unit_test -l message -r detailed'
+docker run --network golos-tests_contracts-net -ti cyberway/golos.worker:$IMAGETAG  /bin/bash -c 'export MONGO_URL=mongodb://mongo:27017; /opt/golos.worker/unit_test -l message -r detailed'
 result=$?
 
 docker-compose down

--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -378,32 +378,8 @@
                     "type": "uint8"
                 },
                 {
-                    "name": "fund_name",
-                    "type": "name"
-                },
-                {
-                    "name": "deposit",
-                    "type": "asset"
-                },
-                {
                     "name": "tspec_id",
                     "type": "tspec_id_t"
-                },
-                {
-                    "name": "worker",
-                    "type": "name"
-                },
-                {
-                    "name": "work_begining_time",
-                    "type": "uint64"
-                },
-                {
-                    "name": "worker_payments_count",
-                    "type": "uint8"
-                },
-                {
-                    "name": "payment_begining_time",
-                    "type": "uint64"
                 },
                 {
                     "name": "created",
@@ -492,6 +468,30 @@
                 {
                     "name": "data",
                     "type": "tspec_data_t"
+                },
+                {
+                    "name": "fund_name",
+                    "type": "name"
+                },
+                {
+                    "name": "deposit",
+                    "type": "asset"
+                },
+                {
+                    "name": "worker",
+                    "type": "name"
+                },
+                {
+                    "name": "work_begining_time",
+                    "type": "uint64"
+                },
+                {
+                    "name": "worker_payments_count",
+                    "type": "uint8"
+                },
+                {
+                    "name": "payment_begining_time",
+                    "type": "uint64"
                 },
                 {
                     "name": "created",

--- a/golos.worker/golos.worker.cpp
+++ b/golos.worker/golos.worker.cpp
@@ -25,13 +25,12 @@ const auto worker::get_proposal(proposal_id_t proposal_id) {
     return proposal;
 }
 
-void worker::deposit(proposal_t& proposal) {
-    const tspec_data_t &tspec = _proposal_tspecs.get(proposal.tspec_id).data;
-    const asset budget = tspec.development_cost + tspec.specification_cost;
-    const auto &fund = _funds.get(proposal.fund_name.value);
+void worker::deposit(tspec_app_t& tspec_app) {
+    const asset budget = tspec_app.data.development_cost + tspec_app.data.specification_cost;
+    const auto& fund = _funds.get(tspec_app.fund_name.value);
     eosio::check(budget <= fund.quantity, "insufficient funds");
 
-    proposal.deposit = budget;
+    tspec_app.deposit = budget;
     _funds.modify(fund, name(), [&](auto &obj) {
         obj.quantity -= budget;
     });
@@ -41,14 +40,12 @@ void worker::choose_proposal_tspec(proposal_t& proposal, const tspec_app_t& tspe
     eosio::check(proposal.type == proposal_t::TYPE_TASK, "invalid state for choose_proposal_tspec");
     proposal.tspec_id = tspec_app.id;
     proposal.set_state(proposal_t::STATE_TSPEC_CHOSE);
-    deposit(proposal);
 }
 
-void worker::pay_tspec_author(proposal_t& proposal) {
-    const tspec_app_t& tspec_app = _proposal_tspecs.get(proposal.tspec_id);
-    const tspec_data_t& tspec = tspec_app.data;
+void worker::pay_tspec_author(tspec_app_t& tspec_app) {
+    const auto& tspec = tspec_app.data;
 
-    proposal.deposit -= tspec.specification_cost;
+    tspec_app.deposit -= tspec.specification_cost;
 
     action(permission_level{_self, "active"_n},
            config::token_name,
@@ -59,15 +56,17 @@ void worker::pay_tspec_author(proposal_t& proposal) {
             .send();
 }
 
-void worker::refund(proposal_t& proposal, eosio::name modifier) {
-    eosio::check(proposal.deposit.amount > 0, "no funds were deposited");
+void worker::refund(tspec_app_t& tspec_app, eosio::name modifier) {
+    if (tspec_app.deposit.amount == 0) {
+        return;
+    }
 
-    const auto &fund = _funds.get(proposal.fund_name.value);
+    const auto& fund = _funds.get(tspec_app.fund_name.value);
     _funds.modify(fund, modifier, [&](auto &obj) {
-        obj.quantity += proposal.deposit;
+        obj.quantity += tspec_app.deposit;
     });
 
-    proposal.deposit = ZERO_ASSET;
+    tspec_app.deposit = ZERO_ASSET;
 }
 
 void worker::close_tspec(name payer, const tspec_app_t& tspec_app, tspec_app_t::state_t state, const proposal_t& proposal) {
@@ -79,6 +78,7 @@ void worker::close_tspec(name payer, const tspec_app_t& tspec_app, tspec_app_t::
     }
     _proposal_tspecs.modify(tspec_app, payer, [&](tspec_app_t& tspec) {
         tspec.set_state(state);
+        refund(tspec, payer);
     });
 }
 
@@ -103,7 +103,6 @@ void worker::addpropos(proposal_id_t proposal_id, const eosio::name& author, con
         o.id = proposal_id;
         o.type = proposal_t::TYPE_TASK;
         o.author = author;
-        o.fund_name = _self;
 
         o.state = (uint8_t)proposal_t::STATE_TSPEC_APP;
         o.created = TIMESTAMP_NOW;
@@ -121,11 +120,7 @@ void worker::addproposdn(proposal_id_t proposal_id, const eosio::name &author, c
         o.id = proposal_id;
         o.type = proposal_t::TYPE_DONE;
         o.author = author;
-        o.fund_name = _self;
         o.tspec_id = tspec_id;
-        o.worker = worker;
-        o.work_begining_time = TIMESTAMP_NOW;
-        o.worker_payments_count = 0;
 
         o.state = (uint8_t)proposal_t::STATE_TSPEC_CHOSE;
         o.created = TIMESTAMP_NOW;
@@ -137,6 +132,10 @@ void worker::addproposdn(proposal_id_t proposal_id, const eosio::name &author, c
         obj.foreign_id = proposal_id;
         obj.author = author;
         obj.data = tspec;
+        obj.fund_name = _self;
+        obj.worker = worker;
+        obj.work_begining_time = TIMESTAMP_NOW;
+        obj.worker_payments_count = 0;
         obj.created = TIMESTAMP_NOW;
         obj.modified = TIMESTAMP_UNDEFINED;
 
@@ -229,6 +228,7 @@ void worker::addtspec(proposal_id_t proposal_id, tspec_id_t tspec_app_id, eosio:
     _proposal_tspecs.emplace(author, [&](tspec_app_t &spec) {
         spec.id = tspec_app_id;
         spec.author = author;
+        spec.fund_name = _self;
         spec.data = tspec;
         spec.foreign_id = proposal_id;
         spec.created = TIMESTAMP_NOW;
@@ -298,6 +298,7 @@ void worker::approvetspec(tspec_id_t tspec_app_id, eosio::name author, comment_i
         });
         _proposal_tspecs.modify(tspec_app, author, [&](tspec_app_t& tspec) {
             tspec.set_state(tspec_app_t::STATE_APPROVED);
+            deposit(tspec);
         });
     }
 }
@@ -324,35 +325,31 @@ void worker::startwork(tspec_id_t tspec_app_id, eosio::name worker) {
     auto proposal_ptr = get_proposal(tspec_app.foreign_id);
     eosio::check(proposal_ptr->type == proposal_t::TYPE_TASK, "unsupported action");
 
-    _proposals.modify(proposal_ptr, tspec_app.author, [&](proposal_t &proposal) {
-        proposal.worker = worker;
-        proposal.work_begining_time = TIMESTAMP_NOW;
-    });
-
     _proposal_tspecs.modify(tspec_app, tspec_app.author, [&](tspec_app_t& tspec) {
         tspec.set_state(tspec_app_t::STATE_WORK);
+        tspec.worker = worker;
+        tspec.work_begining_time = TIMESTAMP_NOW;
     });
 }
 
 void worker::cancelwork(tspec_id_t tspec_app_id, eosio::name initiator) {
     const auto& tspec_app = _proposal_tspecs.get(tspec_app_id);
     eosio::check(tspec_app.state == tspec_app_t::STATE_WORK, "invalid state for cancelwork");
-    auto proposal_ptr = get_proposal(tspec_app.foreign_id);
-    eosio::check(proposal_ptr->type == proposal_t::TYPE_TASK, "unsupported action");
 
-    if (initiator == proposal_ptr->worker)
+    if (initiator == tspec_app.worker)
     {
-        require_auth(proposal_ptr->worker);
+        require_auth(tspec_app.worker);
     }
     else
     {
         require_auth(tspec_app.author);
     }
 
-    _proposals.modify(proposal_ptr, initiator, [&](proposal_t &proposal) {
-        refund(proposal, initiator);
+    _proposal_tspecs.modify(tspec_app, initiator, [&](auto& tspec) {
+        refund(tspec, initiator);
     });
 
+    auto proposal_ptr = get_proposal(tspec_app.foreign_id);
     close_tspec(initiator, tspec_app, tspec_app_t::STATE_CLOSED, *proposal_ptr);
 }
 
@@ -361,8 +358,8 @@ void worker::poststatus(proposal_id_t proposal_id, comment_id_t comment_id, cons
     const auto& tspec_app = _proposal_tspecs.get(proposal_ptr->tspec_id);
     eosio::check(tspec_app.state == tspec_app_t::STATE_WORK, "invalid state for poststatus");
     eosio::check(proposal_ptr->type == proposal_t::TYPE_TASK, "unsupported action");
-    require_auth(proposal_ptr->worker);
-    _proposal_status_comments.add(comment_id, proposal_ptr->id, proposal_ptr->worker, comment);
+    require_auth(tspec_app.worker);
+    _proposal_status_comments.add(comment_id, proposal_ptr->id, tspec_app.worker, comment);
 }
 
 void worker::acceptwork(tspec_id_t tspec_app_id, comment_id_t comment_id, const comment_data_t& comment) {
@@ -384,17 +381,18 @@ void worker::reviewwork(tspec_id_t tspec_app_id, eosio::name reviewer, uint8_t s
     require_app_delegate(reviewer);
 
     const auto& tspec = _proposal_tspecs.get(tspec_app_id);
-    const auto& proposal = _proposals.get(tspec.foreign_id);
 
     vote_t vote {
         .voter = reviewer,
-        .positive = status == proposal_t::STATUS_ACCEPT,
+        .positive = status == tspec_app_t::STATUS_ACCEPT,
         .foreign_id = tspec_app_id
     };
 
     _tspec_review_votes.vote(vote);
 
-    if (static_cast<proposal_t::review_status_t>(status) == proposal_t::STATUS_REJECT) {
+    const auto& proposal = _proposals.get(tspec.foreign_id);
+
+    if (static_cast<tspec_app_t::review_status_t>(status) == tspec_app_t::STATUS_REJECT) {
         eosio::check(tspec.state == tspec_app_t::STATE_DELEGATES_REVIEW ||
                      tspec.state == tspec_app_t::STATE_WORK,
                      "invalid state for negative review");
@@ -404,13 +402,10 @@ void worker::reviewwork(tspec_id_t tspec_app_id, eosio::name reviewer, uint8_t s
         {
             //TODO: check that all voters are delegates in this moment
             LOG("work has been rejected by the delegates voting, got % negative votes", negative_votes_count);
-            _proposals.modify(proposal, reviewer, [&](proposal_t& proposal) {
-                refund(proposal, reviewer);
-            });
 
             close_tspec(reviewer, tspec, tspec_app_t::STATE_CLOSED, proposal);
         }
-    } else {
+    } else if (static_cast<tspec_app_t::review_status_t>(status) == tspec_app_t::STATUS_ACCEPT) {
         eosio::check(tspec.state == tspec_app_t::STATE_DELEGATES_REVIEW, "invalid state for positive review");
 
         size_t positive_votes_count = _tspec_review_votes.count_positive(tspec_app_id);
@@ -419,19 +414,18 @@ void worker::reviewwork(tspec_id_t tspec_app_id, eosio::name reviewer, uint8_t s
             //TODO: check that all voters are delegates in this moment
             LOG("work has been accepted by the delegates voting, got % positive votes", positive_votes_count);
 
-            _proposals.modify(proposal, reviewer, [&](proposal_t& proposal) {
-                if (proposal.deposit.amount == 0 && proposal.type == proposal_t::TYPE_DONE) {
-                    deposit(proposal);
+            _proposal_tspecs.modify(tspec, reviewer, [&](auto& tspec) {
+                if (tspec.deposit.amount == 0 && proposal.type == proposal_t::TYPE_DONE) {
+                    deposit(tspec);
                 }
 
-                pay_tspec_author(proposal);
-                proposal.payment_begining_time = TIMESTAMP_NOW;
-            });
-
-            _proposal_tspecs.modify(tspec, reviewer, [&](tspec_app_t& tspec) {
-                tspec.set_state(tspec_app_t::STATE_PAYMENT);
+                tspec.set_state(tspec_app_t::STATE_PAYMENT); 
+                pay_tspec_author(tspec);
+                tspec.payment_begining_time = TIMESTAMP_NOW;
             });
         }
+    } else {
+        eosio::check(false, "wrong status");
     }
 }
 
@@ -440,15 +434,11 @@ void worker::withdraw(tspec_id_t tspec_app_id) {
     const auto& tspec = tspec_app.data;
     eosio::check(tspec_app.state == tspec_app_t::STATE_PAYMENT, "invalid state for withdraw");
 
-    auto proposal_ptr = get_proposal(tspec_app.foreign_id);
+    require_auth(tspec_app.worker);
 
-    require_auth(proposal_ptr->worker);
-
-    LOG("proposal.worker: %, payments_count: %, payments_interval: %", proposal_ptr->worker,
+    LOG("tspec_app.worker: %, payments_count: %, payments_interval: %", tspec_app.worker,
         static_cast<int>(tspec.payments_count),
         static_cast<int>(tspec.payments_interval));
-
-    require_auth(proposal_ptr->worker);
 
     asset quantity;
 
@@ -458,35 +448,36 @@ void worker::withdraw(tspec_id_t tspec_app_id) {
     }
     else
     {
-        const uint32_t payment_epoch = (eosio::current_time_point().sec_since_epoch() - proposal_ptr->payment_begining_time)
+        const uint32_t payment_epoch = (eosio::current_time_point().sec_since_epoch() - tspec_app.payment_begining_time)
             / tspec.payments_interval;
 
         LOG("payment epoch: %, interval: %s, worker payments: %",
             payment_epoch, tspec.payments_interval,
-            int(proposal_ptr->worker_payments_count));
+            int(tspec_app.worker_payments_count));
 
-        eosio::check(payment_epoch > proposal_ptr->worker_payments_count, "can't withdraw right now");
+        eosio::check(payment_epoch > tspec_app.worker_payments_count, "can't withdraw right now");
 
         quantity = tspec.development_cost / tspec.payments_count;
 
-        if (proposal_ptr->worker_payments_count + 1 == tspec.payments_count)
+        if (tspec_app.worker_payments_count + 1 == tspec.payments_count)
         {
             quantity += asset(tspec.development_cost.amount % tspec.payments_count, quantity.symbol);
         }
     }
 
-    if (proposal_ptr->worker_payments_count+1 == tspec.payments_count) {
-        close_tspec(proposal_ptr->worker, tspec_app, tspec_app_t::STATE_PAYMENT_COMPLETE, *proposal_ptr);
+    if (tspec_app.worker_payments_count+1 == tspec.payments_count) {
+        auto proposal_ptr = get_proposal(tspec_app.foreign_id);
+        close_tspec(tspec_app.worker, tspec_app, tspec_app_t::STATE_PAYMENT_COMPLETE, *proposal_ptr);
     }
 
-    _proposals.modify(proposal_ptr, proposal_ptr->worker, [&](proposal_t &proposal) {
-        proposal.deposit -= quantity;
-        proposal.worker_payments_count += 1;
+    _proposal_tspecs.modify(tspec_app, tspec_app.worker, [&](auto& t) {
+        t.deposit -= quantity;
+        t.worker_payments_count += 1;
     });
 
     action(permission_level{_self, "active"_n},
            config::token_name, "transfer"_n,
-           std::make_tuple(_self, proposal_ptr->worker,
+           std::make_tuple(_self, tspec_app.worker,
                            quantity, std::string("worker reward")))
             .send();
 }

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -242,11 +242,22 @@ public:
             STATE_CLOSED
         };
 
+        enum review_status_t {
+            STATUS_REJECT = 0,
+            STATUS_ACCEPT = 1
+        };
+
         tspec_id_t id;
         tspec_id_t foreign_id;
         eosio::name author;
         uint8_t state;
         tspec_data_t data;
+        eosio::name fund_name;
+        asset deposit;
+        eosio::name worker;
+        uint64_t work_begining_time;
+        uint8_t worker_payments_count;
+        uint64_t payment_begining_time;
         uint64_t created;
         uint64_t modified;
 
@@ -269,11 +280,6 @@ public:
             STATE_TSPEC_CHOSE
         };
 
-        enum review_status_t {
-            STATUS_REJECT = 0,
-            STATUS_ACCEPT = 1
-        };
-
         enum type_t {
             TYPE_TASK,
             TYPE_DONE
@@ -283,13 +289,7 @@ public:
         eosio::name author;
         uint8_t type;
         uint8_t state;
-        eosio::name fund_name;
-        asset deposit;
         tspec_id_t tspec_id;
-        eosio::name worker;
-        uint64_t work_begining_time;
-        uint8_t worker_payments_count;
-        uint64_t payment_begining_time;
         uint64_t created;
         uint64_t modified;
 
@@ -326,10 +326,10 @@ protected:
     auto get_state();
     const auto get_proposal(proposal_id_t proposal_id);
 
-    void deposit(proposal_t &proposal);
+    void deposit(tspec_app_t& tspec_app);
     void choose_proposal_tspec(proposal_t & proposal, const tspec_app_t &tspec_app);
-    void pay_tspec_author(proposal_t & proposal);
-    void refund(proposal_t & proposal, eosio::name modifier);
+    void pay_tspec_author(tspec_app_t& tspec_app);
+    void refund(tspec_app_t& tspec_app, eosio::name modifier);
     void close_tspec(name payer, const tspec_app_t& tspec_app, tspec_app_t::state_t state, const proposal_t& proposal);
     void del_tspec(const tspec_app_t &tspec_app);
 public:

--- a/tests/golos.worker_tests.cpp
+++ b/tests/golos.worker_tests.cpp
@@ -160,7 +160,7 @@ public:
 
         BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_CHOSE);
         // if technical specification application was upvoted, `tspec_deposit` should be deposited from the application fund
-        BOOST_REQUIRE_EQUAL(worker.get_proposal(proposal_id)["deposit"].as<asset>(), tspec_deposit);
+        BOOST_REQUIRE_EQUAL(worker.get_tspec(tspec_app_id)["deposit"].as<asset>(), tspec_deposit);
         BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_app_id), STATE_APPROVED);
 
         /* ok,technical specification application has been choosen,


### PR DESCRIPTION
Resolves #33:
- Moved fields:
```
        eosio::name fund_name;
        asset deposit;
        eosio::name worker;
        uint64_t work_begining_time;
        uint8_t worker_payments_count;
        uint64_t payment_begining_time;
```
- Moved `review_status_t` from proposal to tspec.
- `refund()` is calling from `close_tspec()`, the check that tspec has deposit moved inside `refund()`.
- `deposit()` is calling not from `choose_proposal_tspec()`, but outside.

Resolves #49
- CI takes much time to test `cyberway.contracts`, however it is not very useful - `cyberway.contracts` have their own CI, and also, this repository even not used for deployment now. Do not run these tests, boost CI from 10 min to only 2 min.