### PR TITLE
Closing tspec by author #50 Not-set state for tspecs #60

### DIFF
--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -43,7 +43,7 @@
                 },
                 {
                     "name": "parent_id",
-                    "type": "comment_id_t"
+                    "type": "uint64?"
                 },
                 {
                     "name": "text",
@@ -169,7 +169,7 @@
                 },
                 {
                     "name": "parent_id",
-                    "type": "comment_id_t"
+                    "type": "uint64?"
                 },
                 {
                     "name": "author",
@@ -308,10 +308,6 @@
                     "type": "uint8"
                 },
                 {
-                    "name": "tspec_id",
-                    "type": "tspec_id_t"
-                },
-                {
                     "name": "created",
                     "type": "uint64"
                 },
@@ -413,7 +409,7 @@
                 },
                 {
                     "name": "result_comment_id",
-                    "type": "comment_id_t"
+                    "type": "uint64?"
                 },
                 {
                     "name": "worker_payments_count",
@@ -609,6 +605,10 @@
                 "name": "primary",
                 "unique": true,
                 "orders": [{"field": "id", "order": "asc"}]
+            }, {
+                "name": "comment",
+                "unique": false,
+                "orders": [{"field": "comment_id", "order": "asc"}]
             }]
         },
         {
@@ -683,6 +683,14 @@
                 "name": "foreign",
                 "unique": false,
                 "orders": [{"field": "foreign_id", "order": "asc"}]
+            }, {
+                "name": "comment",
+                "unique": false,
+                "orders": [{"field": "comment_id", "order": "asc"}]
+            }, {
+                "name": "resultc",
+                "unique": false,
+                "orders": [{"field": "result_comment_id", "order": "asc"}]
             }]
         }
     ],

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -73,6 +73,11 @@ public:
             });
         }
 
+        bool empty(uint64_t foreign_id) const {
+            auto index = votes.template get_index<"foreign"_n>();
+            return index.find(foreign_id) == index.end();
+        }
+
         void vote(const vote_t &vote) {
             auto index = votes.template get_index<"foreign"_n>();
             for (auto vote_ptr = index.lower_bound(vote.foreign_id); vote_ptr != index.upper_bound(vote.foreign_id); vote_ptr++) {
@@ -114,6 +119,7 @@ public:
     template <eosio::name::raw TableName>
     struct approve_module_t: protected voting_module_t<TableName> {
         using voting_module_t<TableName>::count_positive;
+        using voting_module_t<TableName>::empty;
         using voting_module_t<TableName>::erase_all;
 
         approve_module_t(const eosio::name& code, uint64_t scope): voting_module_t<TableName>::voting_module_t(code, scope) {}
@@ -184,7 +190,8 @@ public:
             STATE_DELEGATES_REVIEW,
             STATE_PAYMENT,
             STATE_PAYMENT_COMPLETE,
-            STATE_CLOSED
+            STATE_CLOSED_BY_AUTHOR,
+            STATE_CLOSED_BY_WITNESSES
         };
 
         enum review_status_t {
@@ -276,7 +283,6 @@ protected:
     void pay_tspec_author(tspec_app_t& tspec_app);
     void refund(tspec_app_t& tspec_app, eosio::name modifier);
     void close_tspec(name payer, const tspec_app_t& tspec_app, tspec_app_t::state_t state, const proposal_t& proposal);
-    void del_tspec(const tspec_app_t &tspec_app);
 public:
     worker(eosio::name receiver, eosio::name code, eosio::datastream<const char *> ds) : contract(receiver, code, ds),
         _state(_self, _self.value),


### PR DESCRIPTION
Resolve #50:
- Author can delete tspec only if it has no reviews. Otherwise he can only set `STATE_CLOSED_BY_AUTHOR`.
- Proposal cannot be deleted if has tspecs (but if has votes - can be deleted, votes are erasing).

Resolve #60:
- Just remove `tspec_id` from proposal. It just do not need for consensus, at least now.
- Do not delete comment with proposal, tspec, used as result for tspec.
- Instead of hardcoding 0 as "not-set comment id" and "parent id which indicates comment is root", use `std::optional` for comments. (Using optional in tables is my original solution... generally, looks working...)

TODOs:
- Try to use same id for proposal and its comment, and same with tspecs. Having two ids related to same object  seems too complex. Otherwise, there will many complicated logics, for instance - guard from double creating proposal on comment.