### PR TITLE
Refactor approving of tspec #62

### DIFF
--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -134,7 +134,7 @@
             ]
         },
         {
-            "name": "approvetspec",
+            "name": "apprtspec",
             "base": "",
             "fields": [
                 {
@@ -142,7 +142,7 @@
                     "type": "comment_id_t"
                 },
                 {
-                    "name": "author",
+                    "name": "approver",
                     "type": "name"
                 }
             ]
@@ -186,20 +186,6 @@
                 {
                     "name": "token_symbol",
                     "type": "symbol"
-                }
-            ]
-        },
-        {
-            "name": "dapprovetspec",
-            "base": "",
-            "fields": [
-                {
-                    "name": "tspec_id",
-                    "type": "comment_id_t"
-                },
-                {
-                    "name": "author",
-                    "type": "name"
                 }
             ]
         },
@@ -534,8 +520,16 @@
             "type": "edittspec"
         },
         {
-            "name": "approvetspec",
-            "type": "approvetspec"
+            "name": "apprtspec",
+            "type": "apprtspec"
+        },
+        {
+            "name": "dapprtspec",
+            "type": "apprtspec"
+        },
+        {
+            "name": "unapprtspec",
+            "type": "apprtspec"
         },
         {
             "name": "cancelwork",
@@ -544,10 +538,6 @@
         {
             "name": "createpool",
             "type": "createpool"
-        },
-        {
-            "name": "dapprovetspec",
-            "type": "dapprovetspec"
         },
         {
             "name": "delcomment",
@@ -629,19 +619,6 @@
             }]
         },
         {
-            "name": "proposalstsv",
-            "type": "vote_t",
-            "indexes": [{
-                "name": "primary",
-                "unique": true,
-                "orders": [{"field": "id", "order": "asc"}]
-            }, {
-                "name": "foreign",
-                "unique": false,
-                "orders": [{"field": "foreign_id", "order": "asc"}]
-            }]
-        },
-        {
             "name": "proposalsv",
             "type": "vote_t",
             "indexes": [{
@@ -661,6 +638,19 @@
                 "name": "primary",
                 "unique": true,
                 "orders": [{"field": "id", "order": "asc"}]
+            }]
+        },
+        {
+            "name": "tspecv",
+            "type": "vote_t",
+            "indexes": [{
+                "name": "primary",
+                "unique": true,
+                "orders": [{"field": "id", "order": "asc"}]
+            }, {
+                "name": "foreign",
+                "unique": false,
+                "orders": [{"field": "foreign_id", "order": "asc"}]
             }]
         },
         {

--- a/golos.worker/golos.worker.cpp
+++ b/golos.worker/golos.worker.cpp
@@ -293,13 +293,14 @@ void worker::apprtspec(comment_id_t tspec_id, name approver) {
     _tspecs.modify(tspec, approver, [&](auto& tspec) {
         if (tspec.worker != name()) {
             tspec.set_state(tspec_app_t::STATE_WORK);
+            send_tspecstate_event(tspec, tspec_app_t::STATE_WORK);
             tspec.work_begining_time = TIMESTAMP_NOW;
         } else {
             tspec.set_state(tspec_app_t::STATE_APPROVED);
+            send_tspecstate_event(tspec, tspec_app_t::STATE_APPROVED);
         }
         deposit(tspec);
     });
-    send_tspecstate_event(tspec, tspec_app_t::STATE_APPROVED);
 }
 
 void worker::dapprtspec(comment_id_t tspec_id, name approver) {

--- a/golos.worker/golos.worker.cpp
+++ b/golos.worker/golos.worker.cpp
@@ -62,14 +62,14 @@ void worker::close_tspec(name payer, const tspec_app_t& tspec_app, tspec_app_t::
             proposal.set_state(proposal_t::STATE_TSPEC_APP);
         });
     }
-    _proposal_tspecs.modify(tspec_app, payer, [&](tspec_app_t& tspec) {
+    _tspecs.modify(tspec_app, payer, [&](tspec_app_t& tspec) {
         tspec.set_state(state);
         refund(tspec, payer);
     });
     // TODO: do instead of modify
     if (state == tspec_app_t::STATE_CLOSED_BY_AUTHOR
             && _tspec_votes.empty(tspec_app.id) && _tspec_review_votes.empty(tspec_app.id)) {
-        _proposal_tspecs.erase(tspec_app);
+        _tspecs.erase(tspec_app);
         send_tspecerase_event(tspec_app);
     } else {
         send_tspecstate_event(tspec_app, state);
@@ -116,7 +116,7 @@ void worker::addproposdn(comment_id_t proposal_id, const eosio::name& author, co
 
     CHECK_POST(proposal_id, author);
 
-    auto tspec_id = _proposal_tspecs.available_primary_key();
+    auto tspec_id = _tspecs.available_primary_key();
 
     _proposals.emplace(author, [&](proposal_t &o) {
         o.id = proposal_id;
@@ -127,7 +127,7 @@ void worker::addproposdn(comment_id_t proposal_id, const eosio::name& author, co
         o.modified = TIMESTAMP_UNDEFINED;
     });
 
-    _proposal_tspecs.emplace(author, [&](tspec_app_t &obj) {
+    _tspecs.emplace(author, [&](auto& obj) {
         obj.id = tspec_id;
         obj.foreign_id = proposal_id;
         obj.author = author;
@@ -159,7 +159,7 @@ void worker::delpropos(comment_id_t proposal_id) {
     auto proposal_ptr = get_proposal(proposal_id);
     require_app_member(proposal_ptr->author);
 
-    auto tspec_index = _proposal_tspecs.get_index<"foreign"_n>();
+    auto tspec_index = _tspecs.get_index<"foreign"_n>();
     eosio::check(tspec_index.find(proposal_id) == tspec_index.end(), "proposal has tspecs");
 
     _proposals.erase(proposal_ptr);
@@ -201,8 +201,8 @@ void worker::delcomment(comment_id_t comment_id) {
     eosio::check(index.find(comment_id) == index.end(), "comment has child comments");
 
     eosio::check(_proposals.find(comment_id) == _proposals.end(), "comment has proposal");
-    eosio::check(_proposal_tspecs.find(comment_id) == _proposal_tspecs.end(), "comment has tspec");
-    auto tspec_res_idx = _proposal_tspecs.get_index<name("resultc")>();
+    eosio::check(_tspecs.find(comment_id) == _tspecs.end(), "comment has tspec");
+    auto tspec_res_idx = _tspecs.get_index<name("resultc")>();
     eosio::check(tspec_res_idx.find(comment_id) == tspec_res_idx.end(), "comment used as result for tspec");
 
     _comments.erase(comment);
@@ -213,7 +213,7 @@ void worker::addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t pr
     eosio::check(proposal_ptr->type == proposal_t::TYPE_TASK, "unsupported action");
     eosio::check(proposal_ptr->state == proposal_t::STATE_TSPEC_APP, "invalid state for addtspec");
 
-    eosio::check(_proposal_tspecs.find(tspec_id) == _proposal_tspecs.end(), "already exists");
+    eosio::check(_tspecs.find(tspec_id) == _tspecs.end(), "already exists");
 
     CHECK_POST(tspec_id, author);
 
@@ -226,7 +226,7 @@ void worker::addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t pr
         worker = name();
     }
 
-    _proposal_tspecs.emplace(author, [&](auto& o) {
+    _tspecs.emplace(author, [&](auto& o) {
         o.id = tspec_id;
         o.author = author;
         o.set_state(tspec_app_t::STATE_CREATED);
@@ -241,7 +241,7 @@ void worker::addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t pr
 }
 
 void worker::edittspec(comment_id_t tspec_id, const tspec_data_t& tspec, std::optional<name> worker) {
-    const auto& tspec_app = _proposal_tspecs.get(tspec_id);
+    const auto& tspec_app = _tspecs.get(tspec_id);
     const auto& proposal = _proposals.get(tspec_app.foreign_id);
 
     eosio::check(proposal.state == proposal_t::STATE_TSPEC_APP || 
@@ -259,7 +259,7 @@ void worker::edittspec(comment_id_t tspec_id, const tspec_data_t& tspec, std::op
         worker = name();
     }
 
-    _proposal_tspecs.modify(tspec_app, tspec_app.author, [&](auto& o) {
+    _tspecs.modify(tspec_app, tspec_app.author, [&](auto& o) {
         o.modify(tspec, proposal.state == proposal_t::STATE_TSPEC_CHOSE /* limited */);
         o.worker = *worker;
     });
@@ -267,7 +267,7 @@ void worker::edittspec(comment_id_t tspec_id, const tspec_data_t& tspec, std::op
 
 void worker::deltspec(comment_id_t tspec_id)
 {
-    const auto& tspec_app = _proposal_tspecs.get(tspec_id);
+    const auto& tspec_app = _tspecs.get(tspec_id);
     const auto& proposal = _proposals.get(tspec_app.foreign_id);
     eosio::check(tspec_app.state <= tspec_app_t::STATE_PAYMENT, "techspec already closed");
     eosio::check(tspec_app.state < tspec_app_t::STATE_PAYMENT, "techspec paying, cannot delete");
@@ -278,19 +278,19 @@ void worker::deltspec(comment_id_t tspec_id)
 }
 
 void worker::apprtspec(comment_id_t tspec_id, name approver) {
-    const auto& tspec = _proposal_tspecs.get(tspec_id);
+    const auto& tspec = _tspecs.get(tspec_id);
     CHECK_APPROVE_TSPEC(tspec, approver);
     _tspec_votes.vote(tspec_id, approver, true);
 
     //TODO: check that all voters are delegates in this moment
     if (_tspec_votes.count_positive(tspec_id) < config::witness_count_51) {
-    	return;
+        return;
     }
     const auto& proposal = _proposals.get(tspec.foreign_id);
     _proposals.modify(proposal, approver, [&](auto& obj) {
         choose_proposal_tspec(obj, tspec);
     });
-    _proposal_tspecs.modify(tspec, approver, [&](auto& tspec) {
+    _tspecs.modify(tspec, approver, [&](auto& tspec) {
         if (tspec.worker != name()) {
             tspec.set_state(tspec_app_t::STATE_WORK);
             tspec.work_begining_time = TIMESTAMP_NOW;
@@ -303,13 +303,13 @@ void worker::apprtspec(comment_id_t tspec_id, name approver) {
 }
 
 void worker::dapprtspec(comment_id_t tspec_id, name approver) {
-    const auto& tspec = _proposal_tspecs.get(tspec_id);
+    const auto& tspec = _tspecs.get(tspec_id);
     CHECK_APPROVE_TSPEC(tspec, approver);
     _tspec_votes.vote(tspec_id, approver, false);
 
     //TODO: check that all voters are delegates in this moment
     if (_tspec_votes.count_negative(tspec_id) < config::witness_count_75) {
-    	return;
+        return;
     }
     const auto& proposal = _proposals.get(tspec.foreign_id);
     close_tspec(approver, tspec, tspec_app_t::STATE_CLOSED_BY_WITNESSES, proposal);
@@ -317,13 +317,13 @@ void worker::dapprtspec(comment_id_t tspec_id, name approver) {
 }
 
 void worker::unapprtspec(comment_id_t tspec_id, name approver) {
-    const auto& tspec = _proposal_tspecs.get(tspec_id);
+    const auto& tspec = _tspecs.get(tspec_id);
     CHECK_APPROVE_TSPEC(tspec, approver);
     _tspec_votes.erase(tspec_id, approver);
 }
 
 void worker::startwork(comment_id_t tspec_id, name worker) {
-    const auto& tspec_app = _proposal_tspecs.get(tspec_id);
+    const auto& tspec_app = _tspecs.get(tspec_id);
     require_auth(tspec_app.author);
     eosio::check(tspec_app.state == tspec_app_t::STATE_APPROVED, "invalid state for startwork");
 
@@ -332,7 +332,7 @@ void worker::startwork(comment_id_t tspec_id, name worker) {
 
     eosio::check(is_account(worker), "worker account not exists");
 
-    _proposal_tspecs.modify(tspec_app, tspec_app.author, [&](tspec_app_t& tspec) {
+    _tspecs.modify(tspec_app, tspec_app.author, [&](auto& tspec) {
         tspec.set_state(tspec_app_t::STATE_WORK);
         tspec.worker = worker;
         tspec.work_begining_time = TIMESTAMP_NOW;
@@ -340,7 +340,7 @@ void worker::startwork(comment_id_t tspec_id, name worker) {
 }
 
 void worker::cancelwork(comment_id_t tspec_id, eosio::name initiator) {
-    const auto& tspec_app = _proposal_tspecs.get(tspec_id);
+    const auto& tspec_app = _tspecs.get(tspec_id);
     eosio::check(tspec_app.state == tspec_app_t::STATE_WORK, "invalid state");
 
     if (initiator == tspec_app.worker)
@@ -352,7 +352,7 @@ void worker::cancelwork(comment_id_t tspec_id, eosio::name initiator) {
         require_auth(tspec_app.author);
     }
 
-    _proposal_tspecs.modify(tspec_app, initiator, [&](auto& tspec) {
+    _tspecs.modify(tspec_app, initiator, [&](auto& tspec) {
         tspec.set_state(tspec_app_t::STATE_APPROVED);
         tspec.worker = name();
         tspec.work_begining_time = TIMESTAMP_UNDEFINED;
@@ -360,24 +360,24 @@ void worker::cancelwork(comment_id_t tspec_id, eosio::name initiator) {
 }
 
 void worker::acceptwork(comment_id_t tspec_id, comment_id_t result_comment_id) {
-    const auto& tspec_app = _proposal_tspecs.get(tspec_id);
+    const auto& tspec_app = _tspecs.get(tspec_id);
     require_auth(tspec_app.author);
     eosio::check(tspec_app.state == tspec_app_t::STATE_WORK || tspec_app.state == tspec_app_t::STATE_WIP, "invalid state");
 
     CHECK_POST(result_comment_id, tspec_app.author);
 
-    _proposal_tspecs.modify(tspec_app, tspec_app.author, [&](auto& tspec) {
+    _tspecs.modify(tspec_app, tspec_app.author, [&](auto& tspec) {
         tspec.set_state(tspec_app_t::STATE_DELEGATES_REVIEW);
         tspec.result_comment_id = result_comment_id;
     });
 }
 
 void worker::unacceptwork(comment_id_t tspec_id) {
-    const auto& tspec_app = _proposal_tspecs.get(tspec_id);
+    const auto& tspec_app = _tspecs.get(tspec_id);
     require_auth(tspec_app.author);
     eosio::check(tspec_app.state == tspec_app_t::STATE_DELEGATES_REVIEW, "invalid state");
 
-    _proposal_tspecs.modify(tspec_app, tspec_app.author, [&](auto& tspec) {
+    _tspecs.modify(tspec_app, tspec_app.author, [&](auto& tspec) {
         tspec.set_state(tspec_app_t::STATE_WIP);
         tspec.result_comment_id.reset();
     });
@@ -386,7 +386,7 @@ void worker::unacceptwork(comment_id_t tspec_id) {
 void worker::reviewwork(comment_id_t tspec_id, eosio::name reviewer, uint8_t status) {
     require_app_delegate(reviewer);
 
-    const auto& tspec = _proposal_tspecs.get(tspec_id);
+    const auto& tspec = _tspecs.get(tspec_id);
 
     _tspec_review_votes.vote(tspec_id, reviewer, status == tspec_app_t::STATUS_ACCEPT);
 
@@ -420,7 +420,7 @@ void worker::reviewwork(comment_id_t tspec_id, eosio::name reviewer, uint8_t sta
             //TODO: check that all voters are delegates in this moment
             send_tspecstate_event(tspec, tspec_app_t::STATE_PAYMENT);
 
-            _proposal_tspecs.modify(tspec, reviewer, [&](auto& tspec) {
+            _tspecs.modify(tspec, reviewer, [&](auto& tspec) {
                 if (tspec.deposit.amount == 0 && proposal.type == proposal_t::TYPE_DONE) {
                     deposit(tspec);
                 }
@@ -444,7 +444,7 @@ void worker::payout(name ram_payer) {
     };
 
     auto now = TIMESTAMP_NOW;
-    auto tspec_idx = _proposal_tspecs.get_index<name("payout")>();
+    auto tspec_idx = _tspecs.get_index<name("payout")>();
     size_t i = 0;
     for (auto tspec_itr = tspec_idx.begin(); tspec_itr != tspec_idx.end() && tspec_itr->next_payout <= now; ++tspec_itr) {
         if (i++ >= config::max_payed_tspecs_per_action) {

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -235,7 +235,7 @@ public:
     multi_index<"tspecs"_n, tspec_app_t,
         indexed_by<"foreign"_n, const_mem_fun<tspec_app_t, uint64_t, &tspec_app_t::foreign_key>>,
         indexed_by<"resultc"_n, const_mem_fun<tspec_app_t, std::optional<comment_id_t>, &tspec_app_t::by_result>>,
-        indexed_by<"payout"_n, const_mem_fun<tspec_app_t, uint64_t, &tspec_app_t::by_payout>>> _proposal_tspecs;
+        indexed_by<"payout"_n, const_mem_fun<tspec_app_t, uint64_t, &tspec_app_t::by_payout>>> _tspecs;
 
     struct [[eosio::table]] proposal_t {
         enum state_t {
@@ -299,7 +299,7 @@ public:
         _comments(_self, _self.value),
         _proposal_votes(_self, _self.value),
         _tspec_review_votes(_self, _self.value),
-        _proposal_tspecs(_self, _self.value),
+        _tspecs(_self, _self.value),
         _tspec_votes(_self, _self.value) {}
 
     [[eosio::action]] void createpool(eosio::symbol token_symbol);

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -26,6 +26,18 @@ using namespace std;
 
 #define LOG(format, ...) print_f("%::%: " format "\n", _self.to_string().c_str(), __FUNCTION__, ##__VA_ARGS__);
 
+#define CHECK_POST(ID, AUTHOR) { \
+    auto post = _comments.find(ID); \
+    eosio::check(post != _comments.end(), "comment not exists"); \
+    eosio::check(!post->parent_id, "comment is not root"); \
+    eosio::check(post->author == AUTHOR, "comment not your"); \
+}
+
+#define CHECK_APPROVE_TSPEC(TSPEC, APPROVER) \
+    require_app_delegate(approver); \
+    eosio::check(TSPEC.state == tspec_app_t::STATE_CREATED, "invalid state"); \
+    eosio::check(current_time_point().sec_since_epoch() <= TSPEC.created + voting_time_s, "approve time is over");
+
 namespace golos
 {
 class [[eosio::contract]] worker : public contract
@@ -82,20 +94,22 @@ public:
             return index.find(foreign_id) == index.end();
         }
 
-        void vote(const vote_t &vote) {
+        void vote(uint64_t foreign_id, name voter, bool positive) {
             auto index = votes.template get_index<"foreign"_n>();
-            for (auto vote_ptr = index.lower_bound(vote.foreign_id); vote_ptr != index.upper_bound(vote.foreign_id); vote_ptr++) {
-                if (vote_ptr->voter == vote.voter) {
-                    eosio::check(vote_ptr->positive != vote.positive, "the vote already exists");
-                    votes.modify(votes.get(vote_ptr->id), vote.voter, [&](auto &obj) {
-                        obj.positive = vote.positive;
+            for (auto vote_ptr = index.lower_bound(foreign_id); vote_ptr != index.upper_bound(foreign_id); vote_ptr++) {
+                if (vote_ptr->voter == voter) {
+                    eosio::check(vote_ptr->positive != positive, "the vote already exists");
+                    votes.modify(votes.get(vote_ptr->id), voter, [&](auto &obj) {
+                        obj.positive = positive;
                     });
                     return;
                 }
             }
-            votes.emplace(vote.voter, [&](auto &obj) {
-                obj = vote;
+            votes.emplace(voter, [&](auto &obj) {
                 obj.id = votes.available_primary_key();
+                obj.foreign_id = foreign_id;
+                obj.voter = voter;
+                obj.positive = positive;
             });
         }
 
@@ -120,28 +134,9 @@ public:
         }
     };
 
-    template <eosio::name::raw TableName>
-    struct approve_module_t: protected voting_module_t<TableName> {
-        using voting_module_t<TableName>::count_positive;
-        using voting_module_t<TableName>::empty;
-        using voting_module_t<TableName>::erase_all;
-
-        approve_module_t(const eosio::name& code, uint64_t scope): voting_module_t<TableName>::voting_module_t(code, scope) {}
-
-        void approve(uint64_t foreign_id, const eosio::name &approver) {
-            vote_t v {
-                .voter = approver,
-                .positive = true,
-                .foreign_id = foreign_id
-            };
-
-            voting_module_t<TableName>::vote(v);
-        }
-
-        void unapprove(uint64_t foreign_id, const eosio::name &approver) {
-            voting_module_t<TableName>::erase(foreign_id, approver);
-        }
-    };
+    voting_module_t<"proposalsv"_n> _proposal_votes;
+    voting_module_t<"tspecv"_n> _tspec_votes;
+    voting_module_t<"tspecrv"_n> _tspec_review_votes;
 
     struct tspec_data_t {
         asset specification_cost;
@@ -278,10 +273,6 @@ public:
     };
     multi_index<"funds"_n, fund_t> _funds;
 
-    voting_module_t<"proposalsv"_n> _proposal_votes;
-    approve_module_t<"proposalstsv"_n> _proposal_tspec_votes;
-    voting_module_t<"tspecrv"_n> _tspec_review_votes;
-
     struct tspecstate_event {
         comment_id_t id;
         uint8_t state;
@@ -309,7 +300,7 @@ public:
         _proposal_votes(_self, _self.value),
         _tspec_review_votes(_self, _self.value),
         _proposal_tspecs(_self, _self.value),
-        _proposal_tspec_votes(_self, _self.value) {}
+        _tspec_votes(_self, _self.value) {}
 
     [[eosio::action]] void createpool(eosio::symbol token_symbol);
 
@@ -326,8 +317,9 @@ public:
     [[eosio::action]] void addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t proposal_id, const tspec_data_t& tspec, std::optional<name> worker);
     [[eosio::action]] void edittspec(comment_id_t tspec_id, const tspec_data_t &tspec, std::optional<name> worker);
     [[eosio::action]] void deltspec(comment_id_t tspec_id);
-    [[eosio::action]] void approvetspec(comment_id_t tspec_id, eosio::name author);
-    [[eosio::action]] void dapprovetspec(comment_id_t tspec_id, eosio::name author);
+    [[eosio::action]] void apprtspec(comment_id_t tspec_id, name approver);
+    [[eosio::action]] void dapprtspec(comment_id_t tspec_id, name approver);
+    [[eosio::action]] void unapprtspec(comment_id_t tspec_id, name approver);
     [[eosio::action]] void startwork(comment_id_t tspec_id, name worker);
     [[eosio::action]] void cancelwork(comment_id_t tspec_id, eosio::name initiator);
     [[eosio::action]] void acceptwork(comment_id_t tspec_id, comment_id_t result_comment_id);

--- a/tests/golos.worker_tests.cpp
+++ b/tests/golos.worker_tests.cpp
@@ -161,9 +161,9 @@ public:
         {
             const name &delegate = delegates[i];
 
-            ASSERT_SUCCESS(worker.push_action(delegate, N(approvetspec), mvo()
+            ASSERT_SUCCESS(worker.push_action(delegate, N(apprtspec), mvo()
                 ("tspec_id", tspec_app_id)
-                ("author", delegate.to_string())));
+                ("approver", delegate.to_string())));
         }
 
         BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_CHOSE);
@@ -501,13 +501,13 @@ try
             BOOST_REQUIRE_EQUAL(tspec_row["data"]["development_cost"].as<asset>().to_string(), "2.000 APP");
 
             const name& approver = delegates[0];
-            ASSERT_SUCCESS(worker.push_action(approver, N(approvetspec), mvo()
+            ASSERT_SUCCESS(worker.push_action(approver, N(apprtspec), mvo()
                 ("tspec_id", tspec_app_id)
-                ("author", approver)));
+                ("approver", approver)));
 
-            ASSERT_SUCCESS(worker.push_action(approver, N(dapprovetspec), mvo()
+            ASSERT_SUCCESS(worker.push_action(approver, N(unapprtspec), mvo()
                 ("tspec_id", tspec_app_id)
-                ("author", approver)));
+                ("approver", approver)));
 
             ASSERT_SUCCESS(worker.push_action(tspec_author, N(deltspec), mvo()
                 ("tspec_id", tspec_app_id)));


### PR DESCRIPTION
Resolve #62:
- Removed `approve_module_t` because it was designed to support only approving without disapproving.
- Added separate actions - `apprtspec`, `dapprtspec`, `unapprtspec`.
- Some simplifyings in code.

TODO:
- Same for `reviewwork`.
- `unapprtspec` - add check what approve exists.