### PR TITLE
Refactor payments #59

### DIFF
--- a/golos.worker/config.hpp
+++ b/golos.worker/config.hpp
@@ -10,4 +10,8 @@ constexpr int witness_count = 21;
 constexpr int witness_count_51 = witness_count / 2 + 1;
 constexpr int witness_count_75 = witness_count * 3 / 4 + 1;
 
+constexpr unsigned payout_expiration_sec  = 3*60*60;
+constexpr unsigned payout_sender_id = 1;
+constexpr size_t max_payed_tspecs_per_action = 10;
+
 }} // golos::config

--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -396,7 +396,7 @@
                     "type": "uint8"
                 },
                 {
-                    "name": "payment_begining_time",
+                    "name": "next_payout",
                     "type": "uint64"
                 },
                 {

--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -480,12 +480,12 @@
             ]
         },
         {
-            "name": "withdraw",
+            "name": "payout",
             "base": "",
             "fields": [
                 {
-                    "name": "tspec_id",
-                    "type": "comment_id_t"
+                    "name": "ram_payer",
+                    "type": "name"
                 }
             ]
         },
@@ -582,8 +582,8 @@
             "type": "votepropos"
         },
         {
-            "name": "withdraw",
-            "type": "withdraw"
+            "name": "payout",
+            "type": "payout"
         }
     ],
     "events": [
@@ -691,6 +691,10 @@
                 "name": "resultc",
                 "unique": false,
                 "orders": [{"field": "result_comment_id", "order": "asc"}]
+            }, {
+                "name": "payout",
+                "unique": false,
+                "orders": [{"field": "next_payout", "order": "asc"}]
             }]
         }
     ],

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -233,12 +233,14 @@ public:
         uint64_t primary_key() const { return id; }
         uint64_t foreign_key() const { return foreign_id; }
         std::optional<comment_id_t> by_result() const { return result_comment_id; }
+        uint64_t by_payout() const { return next_payout; }
         void set_state(state_t new_state) { state = new_state; }
 
     };
     multi_index<"tspecs"_n, tspec_app_t,
         indexed_by<"foreign"_n, const_mem_fun<tspec_app_t, uint64_t, &tspec_app_t::foreign_key>>,
-        indexed_by<"resultc"_n, const_mem_fun<tspec_app_t, std::optional<comment_id_t>, &tspec_app_t::by_result>>> _proposal_tspecs;
+        indexed_by<"resultc"_n, const_mem_fun<tspec_app_t, std::optional<comment_id_t>, &tspec_app_t::by_result>>,
+        indexed_by<"payout"_n, const_mem_fun<tspec_app_t, uint64_t, &tspec_app_t::by_payout>>> _proposal_tspecs;
 
     struct [[eosio::table]] proposal_t {
         enum state_t {
@@ -331,7 +333,7 @@ public:
     [[eosio::action]] void acceptwork(comment_id_t tspec_id, comment_id_t result_comment_id);
     [[eosio::action]] void unacceptwork(comment_id_t tspec_id);
     [[eosio::action]] void reviewwork(comment_id_t tspec_id, eosio::name reviewer, uint8_t status);
-    [[eosio::action]] void withdraw(comment_id_t tspec_id);
+    [[eosio::action]] void payout(name ram_payer);
 
     void on_transfer(name from, name to, eosio::asset quantity, std::string memo);
 };

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -294,7 +294,6 @@ protected:
 
     void deposit(tspec_app_t& tspec_app);
     void choose_proposal_tspec(proposal_t& proposal, const tspec_app_t &tspec_app);
-    void pay_tspec_author(tspec_app_t& tspec_app);
     void refund(tspec_app_t& tspec_app, eosio::name modifier);
     void close_tspec(name payer, const tspec_app_t& tspec_app, tspec_app_t::state_t state, const proposal_t& proposal);
     void send_tspecstate_event(const tspec_app_t& tspec_app, tspec_app_t::state_t state);

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -22,6 +22,7 @@ using namespace std;
 #define ZERO_ASSET eosio::asset(0, get_state().token_symbol)
 #define TIMESTAMP_UNDEFINED 0
 #define TIMESTAMP_NOW eosio::current_time_point().sec_since_epoch()
+#define TIMESTAMP_MAX UINT32_MAX
 
 #define LOG(format, ...) print_f("%::%: " format "\n", _self.to_string().c_str(), __FUNCTION__, ##__VA_ARGS__);
 
@@ -216,12 +217,13 @@ public:
         uint64_t work_begining_time;
         std::optional<comment_id_t> result_comment_id;
         uint8_t worker_payments_count;
-        uint64_t payment_begining_time;
+        uint64_t next_payout;
         uint64_t created;
         uint64_t modified;
 
         EOSLIB_SERIALIZE(tspec_app_t, (id)(foreign_id)(author)(state)(data)(fund_name)(deposit)(worker)
-            (work_begining_time)(result_comment_id)(worker_payments_count)(payment_begining_time)(created)(modified))
+            (work_begining_time)(result_comment_id)(worker_payments_count)(next_payout)
+            (created)(modified))
 
         void modify(const tspec_data_t &that, bool limited = false) {
             data.update(that, limited);

--- a/tests/golos.worker_tests.cpp
+++ b/tests/golos.worker_tests.cpp
@@ -643,8 +643,8 @@ try
 
         BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_PAYMENT);
 
-        ASSERT_SUCCESS(worker.push_action(worker_account, N(withdraw), mvo()
-            ("tspec_id", tspec_id)));
+        ASSERT_SUCCESS(worker.push_action(worker_account, N(payout), mvo()
+            ("ram_payer", worker_account)));
 
         BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_PAYMENT_COMPLETE);
         BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_CHOSE);
@@ -696,8 +696,8 @@ try
     BOOST_REQUIRE_EQUAL(worker.get_tspec_state(0), STATE_PAYMENT); // addproposdn uses available_primary_key
 
     for (int i = 0; i < payments_count; i++) {
-        ASSERT_SUCCESS(worker.push_action(worker_account, N(withdraw), mvo()
-            ("tspec_id", 0))); // addproposdn uses available_primary_key
+        ASSERT_SUCCESS(worker.push_action(worker_account, N(payout), mvo()
+            ("ram_payer", worker_account))); // addproposdn uses available_primary_key
     }
 
     BOOST_REQUIRE_EQUAL(worker.get_tspec_state(0), STATE_PAYMENT_COMPLETE); // addproposdn uses available_primary_key
@@ -790,9 +790,6 @@ try
 
     BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_CLOSED_BY_WITNESSES);
     BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_APP);
-
-    BOOST_REQUIRE_EQUAL(worker.push_action(worker_account, N(withdraw), mvo()
-        ("tspec_id", tspec_id)), wasm_assert_msg("invalid state for withdraw"));
 
     // if tspec is closed deposit should be refunded to the application fund
     BOOST_REQUIRE_EQUAL(worker.get_fund(worker_code_account, worker_code_account)["quantity"].as<asset>(), app_fund_supply);


### PR DESCRIPTION
Resolve #59:
- Added `next_payout` field to do not calculate it on withdraw and to iterate few tspecs in another commit.
- Removed `payment_begining_time` because it is not more need in consensus after next cashout time added. (another non-con fields will be removed after implementing payment logic to do not add fields again)

- Tspec author payments sending at intervals same as worker ones.

- Withdraw action can be called by anyone, and processes few tspecs.
- And calling automatically on emission.
- If many tspecs (i.e. when importing genesis), it reschedules.
- Rescheduled payout trx always only one.