### PR TITLE
Setting worker on addtspec #70

### DIFF
--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -108,6 +108,28 @@
                 {
                     "name": "tspec",
                     "type": "tspec_data_t"
+                },
+                {
+                    "name": "worker",
+                    "type": "name?"
+                }
+            ]
+        },
+        {
+            "name": "edittspec",
+            "base": "",
+            "fields": [
+                {
+                    "name": "tspec_id",
+                    "type": "comment_id_t"
+                },
+                {
+                    "name": "tspec",
+                    "type": "tspec_data_t"
+                },
+                {
+                    "name": "worker",
+                    "type": "name?"
                 }
             ]
         },
@@ -232,20 +254,6 @@
                 {
                     "name": "proposal_id",
                     "type": "comment_id_t"
-                }
-            ]
-        },
-        {
-            "name": "edittspec",
-            "base": "",
-            "fields": [
-                {
-                    "name": "tspec_id",
-                    "type": "comment_id_t"
-                },
-                {
-                    "name": "tspec",
-                    "type": "tspec_data_t"
                 }
             ]
         },
@@ -522,6 +530,10 @@
             "type": "addtspec"
         },
         {
+            "name": "edittspec",
+            "type": "edittspec"
+        },
+        {
             "name": "approvetspec",
             "type": "approvetspec"
         },
@@ -556,10 +568,6 @@
         {
             "name": "editpropos",
             "type": "editpropos"
-        },
-        {
-            "name": "edittspec",
-            "type": "edittspec"
         },
         {
             "name": "reviewwork",

--- a/golos.worker/golos.worker.cpp
+++ b/golos.worker/golos.worker.cpp
@@ -352,6 +352,8 @@ void worker::startwork(comment_id_t tspec_id, name worker) {
     auto proposal_ptr = get_proposal(tspec_app.foreign_id);
     eosio::check(proposal_ptr->type == proposal_t::TYPE_TASK, "unsupported action");
 
+    eosio::check(is_account(worker), "worker account not exists");
+
     _proposal_tspecs.modify(tspec_app, tspec_app.author, [&](tspec_app_t& tspec) {
         tspec.set_state(tspec_app_t::STATE_WORK);
         tspec.worker = worker;

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -320,12 +320,12 @@ public:
     [[eosio::action]] void editcomment(comment_id_t comment_id, const string& text);
     [[eosio::action]] void delcomment(comment_id_t comment_id);
 
-    [[eosio::action]] void addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t proposal_id, const tspec_data_t& tspec);
-    [[eosio::action]] void edittspec(comment_id_t tspec_id, const tspec_data_t &tspec);
+    [[eosio::action]] void addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t proposal_id, const tspec_data_t& tspec, std::optional<name> worker);
+    [[eosio::action]] void edittspec(comment_id_t tspec_id, const tspec_data_t &tspec, std::optional<name> worker);
     [[eosio::action]] void deltspec(comment_id_t tspec_id);
     [[eosio::action]] void approvetspec(comment_id_t tspec_id, eosio::name author);
     [[eosio::action]] void dapprovetspec(comment_id_t tspec_id, eosio::name author);
-    [[eosio::action]] void startwork(comment_id_t tspec_id, eosio::name worker);
+    [[eosio::action]] void startwork(comment_id_t tspec_id, name worker);
     [[eosio::action]] void cancelwork(comment_id_t tspec_id, eosio::name initiator);
     [[eosio::action]] void acceptwork(comment_id_t tspec_id, comment_id_t result_comment_id);
     [[eosio::action]] void unacceptwork(comment_id_t tspec_id);


### PR DESCRIPTION
Resolve #70:
- Setting worker on adding tspec.
- If worker set, jumping to STATE_WORK on approve, not calling `startwork`.

+ Checking worker account exists on startwork.