### PR TITLE
Refactor done propos #69 and editpropos #20

### DIFF
--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -72,6 +72,20 @@
             ]
         },
         {
+            "name": "editpropos",
+            "base": "",
+            "fields": [
+                {
+                    "name": "proposal_id",
+                    "type": "comment_id_t"
+                },
+                {
+                    "name": "type",
+                    "type": "uint8"
+                }
+            ]
+        },
+        {
             "name": "addtspec",
             "base": "",
             "fields": [
@@ -212,16 +226,6 @@
                 {
                     "name": "text",
                     "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "editpropos",
-            "base": "",
-            "fields": [
-                {
-                    "name": "proposal_id",
-                    "type": "comment_id_t"
                 }
             ]
         },
@@ -490,6 +494,10 @@
             "type": "addpropos"
         },
         {
+            "name": "editpropos",
+            "type": "editpropos"
+        },
+        {
             "name": "addtspec",
             "type": "addtspec"
         },
@@ -532,10 +540,6 @@
         {
             "name": "editcomment",
             "type": "editcomment"
-        },
-        {
-            "name": "editpropos",
-            "type": "editpropos"
         },
         {
             "name": "reviewwork",

--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -64,28 +64,10 @@
                 {
                     "name": "author",
                     "type": "name"
-                }
-            ]
-        },
-        {
-            "name": "addproposdn",
-            "base": "",
-            "fields": [
-                {
-                    "name": "proposal_id",
-                    "type": "comment_id_t"
                 },
                 {
-                    "name": "author",
-                    "type": "name"
-                },
-                {
-                    "name": "worker",
-                    "type": "name"
-                },
-                {
-                    "name": "tspec",
-                    "type": "tspec_data_t"
+                    "name": "type",
+                    "type": "uint8"
                 }
             ]
         },
@@ -506,10 +488,6 @@
         {
             "name": "addpropos",
             "type": "addpropos"
-        },
-        {
-            "name": "addproposdn",
-            "type": "addproposdn"
         },
         {
             "name": "addtspec",

--- a/golos.worker/golos.worker.cpp
+++ b/golos.worker/golos.worker.cpp
@@ -257,7 +257,7 @@ void worker::apprtspec(comment_id_t tspec_id, name approver) {
         return;
     }
     const auto& proposal = _proposals.get(tspec.foreign_id);
-    _proposals.modify(proposal, approver, [&](auto& obj) {
+    _proposals.modify(proposal, approver, [&](auto& p) {
         p.set_state(proposal_t::STATE_TSPEC_CHOSE);
     });
     _tspecs.modify(tspec, approver, [&](auto& tspec) {

--- a/golos.worker/golos.worker.cpp
+++ b/golos.worker/golos.worker.cpp
@@ -38,11 +38,6 @@ void worker::deposit(tspec_app_t& tspec_app) {
     });
 }
 
-void worker::choose_proposal_tspec(proposal_t& proposal, const tspec_app_t& tspec_app) {
-    eosio::check(proposal.type == proposal_t::TYPE_TASK, "invalid state for choose_proposal_tspec");
-    proposal.set_state(proposal_t::STATE_TSPEC_CHOSE);
-}
-
 void worker::refund(tspec_app_t& tspec_app, eosio::name modifier) {
     if (tspec_app.deposit.amount == 0) {
         return;
@@ -92,7 +87,8 @@ void worker::createpool(eosio::symbol token_symbol) {
     _state.set(state, _self);
 }
 
-void worker::addpropos(comment_id_t proposal_id, const eosio::name& author) {
+void worker::addpropos(comment_id_t proposal_id, name author, uint8_t type) {
+    eosio::check(type <= proposal_t::TYPE_DONE, "wrong type");
     require_app_member(author);
 
     eosio::check(_proposals.find(proposal_id) == _proposals.end(), "already exists");
@@ -101,46 +97,11 @@ void worker::addpropos(comment_id_t proposal_id, const eosio::name& author) {
 
     _proposals.emplace(author, [&](auto &o) {
         o.id = proposal_id;
-        o.type = proposal_t::TYPE_TASK;
+        o.type = type;
         o.author = author;
         o.state = (uint8_t)proposal_t::STATE_TSPEC_APP;
         o.created = TIMESTAMP_NOW;
         o.modified = TIMESTAMP_UNDEFINED;
-    });
-}
-
-void worker::addproposdn(comment_id_t proposal_id, const eosio::name& author, const eosio::name& worker, const tspec_data_t& tspec) {
-    require_app_member(author);
-
-    eosio::check(_proposals.find(proposal_id) == _proposals.end(), "already exists");
-
-    CHECK_POST(proposal_id, author);
-
-    auto tspec_id = _tspecs.available_primary_key();
-
-    _proposals.emplace(author, [&](proposal_t &o) {
-        o.id = proposal_id;
-        o.type = proposal_t::TYPE_DONE;
-        o.author = author;
-        o.state = (uint8_t)proposal_t::STATE_TSPEC_CHOSE;
-        o.created = TIMESTAMP_NOW;
-        o.modified = TIMESTAMP_UNDEFINED;
-    });
-
-    _tspecs.emplace(author, [&](auto& obj) {
-        obj.id = tspec_id;
-        obj.foreign_id = proposal_id;
-        obj.author = author;
-        obj.data = tspec;
-        obj.fund_name = _self;
-        obj.worker = worker;
-        obj.work_begining_time = TIMESTAMP_NOW;
-        obj.worker_payments_count = 0;
-        obj.next_payout = TIMESTAMP_MAX;
-        obj.created = TIMESTAMP_NOW;
-        obj.modified = TIMESTAMP_UNDEFINED;
-
-        obj.set_state(tspec_app_t::STATE_DELEGATES_REVIEW);
     });
 }
 
@@ -210,7 +171,6 @@ void worker::delcomment(comment_id_t comment_id) {
 
 void worker::addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t proposal_id, const tspec_data_t& tspec, std::optional<name> worker) {
     auto proposal_ptr = get_proposal(proposal_id);
-    eosio::check(proposal_ptr->type == proposal_t::TYPE_TASK, "unsupported action");
     eosio::check(proposal_ptr->state == proposal_t::STATE_TSPEC_APP, "invalid state for addtspec");
 
     eosio::check(_tspecs.find(tspec_id) == _tspecs.end(), "already exists");
@@ -219,6 +179,11 @@ void worker::addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t pr
 
     eosio::check(get_state().token_symbol == tspec.specification_cost.symbol, "invalid symbol for the specification cost");
     eosio::check(get_state().token_symbol == tspec.development_cost.symbol, "invalid symbol for the development cost");
+
+    if (proposal_ptr->type == proposal_t::TYPE_DONE) {
+        eosio::check(author == proposal_ptr->author, "you are not proposal author");
+        eosio::check(worker.has_value(), "worker not set for done tspec");
+    }
 
     if (worker) {
         eosio::check(is_account(*worker), "worker account not exists");
@@ -252,6 +217,10 @@ void worker::edittspec(comment_id_t tspec_id, const tspec_data_t& tspec, std::op
     eosio::check(get_state().token_symbol == tspec.development_cost.symbol, "invalid symbol for the development cost");
 
     require_app_member(tspec_app.author);
+
+    if (proposal.type == proposal_t::TYPE_DONE) {
+        eosio::check(worker.has_value(), "worker not set for done tspec");
+    }
 
     if (worker) {
         eosio::check(is_account(*worker), "worker account not exists");
@@ -288,10 +257,14 @@ void worker::apprtspec(comment_id_t tspec_id, name approver) {
     }
     const auto& proposal = _proposals.get(tspec.foreign_id);
     _proposals.modify(proposal, approver, [&](auto& obj) {
-        choose_proposal_tspec(obj, tspec);
+        p.set_state(proposal_t::STATE_TSPEC_CHOSE);
     });
     _tspecs.modify(tspec, approver, [&](auto& tspec) {
-        if (tspec.worker != name()) {
+        if (proposal.type == proposal_t::TYPE_DONE) {
+            tspec.set_state(tspec_app_t::STATE_PAYMENT);
+            send_tspecstate_event(tspec, tspec_app_t::STATE_PAYMENT);
+            tspec.next_payout = TIMESTAMP_NOW + tspec.data.payments_interval;
+        } else if (tspec.worker != name()) {
             tspec.set_state(tspec_app_t::STATE_WORK);
             send_tspecstate_event(tspec, tspec_app_t::STATE_WORK);
             tspec.work_begining_time = TIMESTAMP_NOW;
@@ -522,7 +495,7 @@ void worker::on_transfer(name from, name to, eosio::asset quantity, std::string 
 } // golos
 
 DISPATCH_WITH_TRANSFER(golos::worker, config::token_name, on_transfer, (createpool)
-    (addproposdn)(addpropos)(editpropos)(delpropos)(votepropos)
+    (addpropos)(editpropos)(delpropos)(votepropos)
     (addcomment)(editcomment)(delcomment)
     (addtspec)(edittspec)(deltspec)(apprtspec)(dapprtspec)(unapprtspec)(startwork)(acceptwork)(unacceptwork)(reviewwork)(cancelwork)
     (payout)

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -286,7 +286,6 @@ protected:
     const auto get_proposal(comment_id_t proposal_id);
 
     void deposit(tspec_app_t& tspec_app);
-    void choose_proposal_tspec(proposal_t& proposal, const tspec_app_t &tspec_app);
     void refund(tspec_app_t& tspec_app, eosio::name modifier);
     void close_tspec(name payer, const tspec_app_t& tspec_app, tspec_app_t::state_t state, const proposal_t& proposal);
     void send_tspecstate_event(const tspec_app_t& tspec_app, tspec_app_t::state_t state);
@@ -304,8 +303,7 @@ public:
 
     [[eosio::action]] void createpool(eosio::symbol token_symbol);
 
-    [[eosio::action]] void addpropos(comment_id_t proposal_id, const eosio::name& author);
-    [[eosio::action]] void addproposdn(comment_id_t proposal_id, const eosio::name& author, const eosio::name& worker, const tspec_data_t& tspec);
+    [[eosio::action]] void addpropos(comment_id_t proposal_id, name author, uint8_t type);
     [[eosio::action]] void editpropos(comment_id_t proposal_id);
     [[eosio::action]] void delpropos(comment_id_t proposal_id);
     [[eosio::action]] void votepropos(comment_id_t proposal_id, eosio::name voter, uint8_t positive);

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -38,6 +38,11 @@ using namespace std;
     eosio::check(TSPEC.state == tspec_app_t::STATE_CREATED, "invalid state"); \
     eosio::check(current_time_point().sec_since_epoch() <= TSPEC.created + voting_time_s, "approve time is over");
 
+#define CHECK_PROPOSAL_NO_TSPECS(PROPOSAL) {\
+    auto tspec_index = _tspecs.get_index<"foreign"_n>();\
+    eosio::check(tspec_index.find(PROPOSAL.id) == tspec_index.end(), "proposal has tspecs");\
+}
+
 namespace golos
 {
 class [[eosio::contract]] worker : public contract
@@ -304,7 +309,7 @@ public:
     [[eosio::action]] void createpool(eosio::symbol token_symbol);
 
     [[eosio::action]] void addpropos(comment_id_t proposal_id, name author, uint8_t type);
-    [[eosio::action]] void editpropos(comment_id_t proposal_id);
+    [[eosio::action]] void editpropos(comment_id_t proposal_id, uint8_t type);
     [[eosio::action]] void delpropos(comment_id_t proposal_id);
     [[eosio::action]] void votepropos(comment_id_t proposal_id, eosio::name voter, uint8_t positive);
 

--- a/tests/golos.worker_tests.cpp
+++ b/tests/golos.worker_tests.cpp
@@ -39,6 +39,11 @@ enum proposal_state_t {
     STATE_TSPEC_CHOSE
 };
 
+enum type_t {
+    TYPE_TASK,
+    TYPE_DONE
+};
+
 enum tspec_state_t {
     STATE_CREATED = 1,
     STATE_APPROVED,
@@ -112,7 +117,8 @@ public:
             ("text", long_text)));
         ASSERT_SUCCESS(worker.push_action(proposal_author, N(addpropos), mvo()
             ("proposal_id", proposal_id)
-            ("author", proposal_author)));
+            ("author", proposal_author)
+            ("type", static_cast<uint8_t>(TYPE_TASK))));
 
         produce_blocks(1);
 
@@ -225,7 +231,8 @@ try
             ("proposal_id", proposal_id)
             ("author", author_account)
             ("title", "Proposal #1")
-            ("description", "Description #1")));
+            ("description", "Description #1")
+            ("type", static_cast<uint8_t>(TYPE_TASK))));
         return;
         auto proposal_row = worker.get_proposal(proposal_id);
         BOOST_REQUIRE_EQUAL(proposal_row["state"], STATE_TSPEC_APP);
@@ -373,7 +380,8 @@ try
         ("text", "Proposal #1")));
     ASSERT_SUCCESS(worker.push_action(members[0], N(addpropos), mvo()
         ("proposal_id", proposal_id)
-        ("author", members[0])));
+        ("author", members[0])
+        ("type", static_cast<uint8_t>(TYPE_TASK))));
 
     BOOST_REQUIRE_EQUAL(worker.get_proposal_votes(worker_code_account).size(), 0);
 
@@ -451,7 +459,8 @@ try
             ("text", "Proposal #1")));
         ASSERT_SUCCESS(worker.push_action(proposal_author, N(addpropos), mvo()
             ("proposal_id", proposal_id)
-            ("author", proposal_author))
+            ("author", proposal_author)
+            ("type", static_cast<uint8_t>(TYPE_TASK)))
         );
 
         BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_APP);
@@ -540,7 +549,8 @@ try
         ("text", "Proposal #1")));
     ASSERT_SUCCESS(worker.push_action(proposal_author, N(addpropos), mvo()
         ("proposal_id", proposal_id)
-        ("author", proposal_author))
+        ("author", proposal_author)
+        ("type", static_cast<uint8_t>(TYPE_TASK)))
     );
 
     BOOST_REQUIRE_EQUAL(worker.get_proposals(worker_code_account).size(), 1);
@@ -662,45 +672,54 @@ try
 
     auto& author_account = members[0];
     auto& worker_account = members[1];
-    uint64_t proposal_id = 1;
+    uint64_t proposal_id = 0;
+    uint64_t tspec_id = 1;
     int payments_count = 3;
 
     ASSERT_SUCCESS(worker.push_action(author_account, N(addcomment), mvo()
         ("comment_id", proposal_id)
         ("author", author_account)
-        ("text", "Sposnored proposal #1"))); // TODO: tspec should have separate post
-    ASSERT_SUCCESS(worker.push_action(author_account, N(addproposdn), mvo()
+        ("text", "Sponsored proposal #1")));
+    ASSERT_SUCCESS(worker.push_action(author_account, N(addpropos), mvo()
         ("proposal_id", proposal_id)
         ("author", author_account)
-        ("worker", worker_account)
+        ("type", static_cast<uint8_t>(TYPE_DONE))));
+
+    ASSERT_SUCCESS(worker.push_action(author_account, N(addcomment), mvo()
+        ("comment_id", tspec_id)
+        ("author", author_account)
+        ("text", "Technical specification #1")));
+    ASSERT_SUCCESS(worker.push_action(author_account, N(addtspec), mvo()
+        ("tspec_id", tspec_id)
+        ("author", author_account)
+        ("proposal_id", proposal_id)
         ("tspec", mvo()
             ("specification_cost", "5.000 APP")
             ("specification_eta", 1)
             ("development_cost", "5.000 APP")
             ("development_eta", 1)
             ("payments_count", payments_count)
-            ("payments_interval", 1)
-        )));
+            ("payments_interval", 1))
+        ("worker", worker_account)));
 
-    BOOST_REQUIRE_EQUAL(worker.get_tspec_state(0), STATE_DELEGATES_REVIEW); // addproposdn uses available_primary_key
+    // vote for the 0 technical specification application
+    for (size_t i = 0; i < delegates_51; i++) {
+        const auto& delegate = delegates[i];
 
-    int i = 0;
-    for (const auto &account : delegates) {
-        ASSERT_SUCCESS(worker.push_action(account, N(reviewwork), mvo()
-            ("tspec_id", 0) // addproposdn uses available_primary_key
-            ("reviewer", account.to_string())
-            ("status", (i + 1) % 2)));
-        i++;
+        ASSERT_SUCCESS(worker.push_action(delegate, N(approvetspec), mvo()
+            ("tspec_id", tspec_id)
+            ("author", delegate.to_string())));
     }
 
-    BOOST_REQUIRE_EQUAL(worker.get_tspec_state(0), STATE_PAYMENT); // addproposdn uses available_primary_key
+    BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_PAYMENT);
 
     for (int i = 0; i < payments_count; i++) {
+        produce_block();
         ASSERT_SUCCESS(worker.push_action(worker_account, N(payout), mvo()
-            ("ram_payer", worker_account))); // addproposdn uses available_primary_key
+            ("ram_payer", worker_account)));
     }
 
-    BOOST_REQUIRE_EQUAL(worker.get_tspec_state(0), STATE_PAYMENT_COMPLETE); // addproposdn uses available_primary_key
+    BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_PAYMENT_COMPLETE);
     BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_CHOSE);
 
     BOOST_REQUIRE_EQUAL(token.get_account(worker_account)["balance"], "15.000 APP");

--- a/tests/golos.worker_tests.cpp
+++ b/tests/golos.worker_tests.cpp
@@ -706,9 +706,9 @@ try
     for (size_t i = 0; i < delegates_51; i++) {
         const auto& delegate = delegates[i];
 
-        ASSERT_SUCCESS(worker.push_action(delegate, N(approvetspec), mvo()
+        ASSERT_SUCCESS(worker.push_action(delegate, N(apprtspec), mvo()
             ("tspec_id", tspec_id)
-            ("author", delegate.to_string())));
+            ("approver", delegate.to_string())));
     }
 
     BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_PAYMENT);


### PR DESCRIPTION
Resolves #69:
- `addproposdn` removed, instead it added `type` to `addpropos`.
- Tspec for done proposal requires worker set on creation.
- Approving such tspec by witnesses sets its state to payment.

Resolves #20:
- `editpropos` allows changing proposal type.
- `editpropos` can be called if proposal has no tspecs, not just hasnt approved tspec.