### PR TITLE
Separate reviewwork to 3 actions #72

### DIFF
--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -54,6 +54,30 @@
             ]
         },
         {
+            "name": "editcomment",
+            "base": "",
+            "fields": [
+                {
+                    "name": "comment_id",
+                    "type": "comment_id_t"
+                },
+                {
+                    "name": "text",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "name": "delcomment",
+            "base": "",
+            "fields": [
+                {
+                    "name": "comment_id",
+                    "type": "comment_id_t"
+                }
+            ]
+        },
+        {
             "name": "addpropos",
             "base": "",
             "fields": [
@@ -82,6 +106,16 @@
                 {
                     "name": "type",
                     "type": "uint8"
+                }
+            ]
+        },
+        {
+            "name": "delpropos",
+            "base": "",
+            "fields": [
+                {
+                    "name": "proposal_id",
+                    "type": "comment_id_t"
                 }
             ]
         },
@@ -130,7 +164,17 @@
             ]
         },
         {
-            "name": "apprtspec",
+            "name": "deltspec",
+            "base": "",
+            "fields": [
+                {
+                    "name": "tspec_id",
+                    "type": "comment_id_t"
+                }
+            ]
+        },
+        {
+            "name": "approve",
             "base": "",
             "fields": [
                 {
@@ -186,50 +230,6 @@
             ]
         },
         {
-            "name": "delcomment",
-            "base": "",
-            "fields": [
-                {
-                    "name": "comment_id",
-                    "type": "comment_id_t"
-                }
-            ]
-        },
-        {
-            "name": "delpropos",
-            "base": "",
-            "fields": [
-                {
-                    "name": "proposal_id",
-                    "type": "comment_id_t"
-                }
-            ]
-        },
-        {
-            "name": "deltspec",
-            "base": "",
-            "fields": [
-                {
-                    "name": "tspec_id",
-                    "type": "comment_id_t"
-                }
-            ]
-        },
-        {
-            "name": "editcomment",
-            "base": "",
-            "fields": [
-                {
-                    "name": "comment_id",
-                    "type": "comment_id_t"
-                },
-                {
-                    "name": "text",
-                    "type": "string"
-                }
-            ]
-        },
-        {
             "name": "fund_t",
             "base": "",
             "fields": [
@@ -270,24 +270,6 @@
                 {
                     "name": "modified",
                     "type": "uint64"
-                }
-            ]
-        },
-        {
-            "name": "reviewwork",
-            "base": "",
-            "fields": [
-                {
-                    "name": "tspec_id",
-                    "type": "comment_id_t"
-                },
-                {
-                    "name": "reviewer",
-                    "type": "name"
-                },
-                {
-                    "name": "status",
-                    "type": "uint8"
                 }
             ]
         },
@@ -478,14 +460,6 @@
     ],
     "actions": [
         {
-            "name": "acceptwork",
-            "type": "acceptwork"
-        },
-        {
-            "name": "unacceptwork",
-            "type": "unacceptwork"
-        },
-        {
             "name": "addcomment",
             "type": "addcomment"
         },
@@ -507,19 +481,43 @@
         },
         {
             "name": "apprtspec",
-            "type": "apprtspec"
+            "type": "approve"
         },
         {
             "name": "dapprtspec",
-            "type": "apprtspec"
+            "type": "approve"
         },
         {
             "name": "unapprtspec",
-            "type": "apprtspec"
+            "type": "approve"
+        },
+        {
+            "name": "startwork",
+            "type": "startwork"
         },
         {
             "name": "cancelwork",
             "type": "cancelwork"
+        },
+        {
+            "name": "acceptwork",
+            "type": "acceptwork"
+        },
+        {
+            "name": "unacceptwork",
+            "type": "unacceptwork"
+        },
+        {
+            "name": "apprwork",
+            "type": "approve"
+        },
+        {
+            "name": "dapprwork",
+            "type": "approve"
+        },
+        {
+            "name": "unapprwork",
+            "type": "approve"
         },
         {
             "name": "createpool",
@@ -540,14 +538,6 @@
         {
             "name": "editcomment",
             "type": "editcomment"
-        },
-        {
-            "name": "reviewwork",
-            "type": "reviewwork"
-        },
-        {
-            "name": "startwork",
-            "type": "startwork"
         },
         {
             "name": "votepropos",

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -201,11 +201,6 @@ public:
             STATE_DISAPPROVED_BY_WITNESSES
         };
 
-        enum review_status_t {
-            STATUS_REJECT = 0,
-            STATUS_ACCEPT = 1
-        };
-
         comment_id_t id;
         comment_id_t foreign_id;
         eosio::name author;
@@ -320,14 +315,20 @@ public:
     [[eosio::action]] void addtspec(comment_id_t tspec_id, eosio::name author, comment_id_t proposal_id, const tspec_data_t& tspec, std::optional<name> worker);
     [[eosio::action]] void edittspec(comment_id_t tspec_id, const tspec_data_t &tspec, std::optional<name> worker);
     [[eosio::action]] void deltspec(comment_id_t tspec_id);
+
     [[eosio::action]] void apprtspec(comment_id_t tspec_id, name approver);
     [[eosio::action]] void dapprtspec(comment_id_t tspec_id, name approver);
     [[eosio::action]] void unapprtspec(comment_id_t tspec_id, name approver);
+
     [[eosio::action]] void startwork(comment_id_t tspec_id, name worker);
     [[eosio::action]] void cancelwork(comment_id_t tspec_id, eosio::name initiator);
     [[eosio::action]] void acceptwork(comment_id_t tspec_id, comment_id_t result_comment_id);
     [[eosio::action]] void unacceptwork(comment_id_t tspec_id);
-    [[eosio::action]] void reviewwork(comment_id_t tspec_id, eosio::name reviewer, uint8_t status);
+
+    [[eosio::action]] void apprwork(comment_id_t tspec_id, name approver);
+    [[eosio::action]] void dapprwork(comment_id_t tspec_id, name approver);
+    [[eosio::action]] void unapprwork(comment_id_t tspec_id, name approver);
+
     [[eosio::action]] void payout(name ram_payer);
 
     void on_transfer(name from, name to, eosio::asset quantity, std::string memo);

--- a/tests/golos.worker_tests.cpp
+++ b/tests/golos.worker_tests.cpp
@@ -645,10 +645,15 @@ try
 
         for (size_t i = 0; i < delegates.size(); i++) {
             const auto& delegate = delegates[i];
-            ASSERT_SUCCESS(worker.push_action(delegate, N(reviewwork), mvo()
-                ("tspec_id", tspec_id)
-                ("reviewer", delegate.to_string())
-                ("status", (i + 1) % 2)));
+            if ((i + 1) % 2) {
+                ASSERT_SUCCESS(worker.push_action(delegate, N(apprwork), mvo()
+                    ("tspec_id", tspec_id)
+                    ("approver", delegate.to_string())));
+            } else {
+                ASSERT_SUCCESS(worker.push_action(delegate, N(dapprwork), mvo()
+                    ("tspec_id", tspec_id)
+                    ("approver", delegate.to_string())));
+            }
         }
 
         BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_PAYMENT);
@@ -800,11 +805,10 @@ try
     BOOST_REQUIRE_EQUAL(worker.get_fund(worker_code_account, worker_code_account)["quantity"].as<asset>(), app_fund_supply - tspec_deposit);
 
     for (size_t i = 0; i < delegates.size() * 3 / 4 + 1; i++) {
-        const name &delegate = delegates[i];
-        ASSERT_SUCCESS(worker.push_action(delegate, N(reviewwork), mvo()
+        const auto& delegate = delegates[i];
+        ASSERT_SUCCESS(worker.push_action(delegate, N(dapprwork), mvo()
             ("tspec_id", tspec_id)
-            ("reviewer", delegate)
-            ("status", 0)));
+            ("approver", delegate)));
     }
 
     BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_id), STATE_CLOSED_BY_WITNESSES);


### PR DESCRIPTION
Resolve #72:
- `reviewwork` separated to `apprwork`, `dapprwork` and `unapprwork`.
- Availability to cancel work approves.
- Fixed event on work approving.