### PR TITLE
Remove tspec eta #77

### DIFF
--- a/golos.worker/golos.worker.abi
+++ b/golos.worker/golos.worker.abi
@@ -390,16 +390,8 @@
                     "type": "asset"
                 },
                 {
-                    "name": "specification_eta",
-                    "type": "uint32"
-                },
-                {
                     "name": "development_cost",
                     "type": "asset"
-                },
-                {
-                    "name": "development_eta",
-                    "type": "uint32"
                 },
                 {
                     "name": "payments_count",

--- a/golos.worker/golos.worker.cpp
+++ b/golos.worker/golos.worker.cpp
@@ -210,9 +210,7 @@ void worker::edittspec(comment_id_t tspec_id, const tspec_data_t& tspec, std::op
     const auto& tspec_app = _tspecs.get(tspec_id);
     const auto& proposal = _proposals.get(tspec_app.foreign_id);
 
-    eosio::check(proposal.state == proposal_t::STATE_TSPEC_APP || 
-                 proposal.state == proposal_t::STATE_TSPEC_CHOSE, "invalid state for edittspec");
-    eosio::check(proposal.type == proposal_t::TYPE_TASK, "unsupported action");
+    eosio::check(proposal.state == proposal_t::STATE_TSPEC_APP, "invalid state");
 
     eosio::check(get_state().token_symbol == tspec.specification_cost.symbol, "invalid symbol for the specification cost");
     eosio::check(get_state().token_symbol == tspec.development_cost.symbol, "invalid symbol for the development cost");
@@ -230,8 +228,9 @@ void worker::edittspec(comment_id_t tspec_id, const tspec_data_t& tspec, std::op
     }
 
     _tspecs.modify(tspec_app, tspec_app.author, [&](auto& o) {
-        o.modify(tspec, proposal.state == proposal_t::STATE_TSPEC_CHOSE /* limited */);
+        o.data = tspec;
         o.worker = *worker;
+        o.modified = TIMESTAMP_NOW;
     });
 }
 

--- a/golos.worker/golos.worker.hpp
+++ b/golos.worker/golos.worker.hpp
@@ -145,46 +145,11 @@ public:
 
     struct tspec_data_t {
         asset specification_cost;
-        uint32_t specification_eta;
         asset development_cost;
-        uint32_t development_eta;
         uint16_t payments_count;
         uint32_t payments_interval;
 
-        EOSLIB_SERIALIZE(tspec_data_t, (specification_cost)(specification_eta)(development_cost)(development_eta)(payments_count)(payments_interval))
-
-        void update(const tspec_data_t &that, bool limited) {
-            bool modified = false;
-
-            if (that.specification_cost.amount != 0) {
-                eosio::check(!limited, "cost can't be modified");
-                specification_cost = that.specification_cost;
-                modified = true;
-            }
-
-            if (that.specification_eta != 0) {
-                specification_eta = that.specification_eta;
-                modified = true;
-            }
-
-            if (that.development_cost.amount != 0) {
-                eosio::check(!limited, "cost can be modified");
-                development_cost = that.development_cost;
-                modified = true;
-            }
-
-            if (that.development_eta != 0) {
-                development_eta = that.development_eta;
-                modified = true;
-            }
-
-            if (that.payments_count != 0) {
-                payments_count = that.payments_count;
-                modified = true;
-            }
-
-            eosio::check(modified, "nothing to modify");
-        }
+        EOSLIB_SERIALIZE(tspec_data_t, (specification_cost)(development_cost)(payments_count)(payments_interval))
     };
 
     struct [[eosio::table]] tspec_app_t {
@@ -224,11 +189,6 @@ public:
         EOSLIB_SERIALIZE(tspec_app_t, (id)(foreign_id)(author)(state)(data)(fund_name)(deposit)(worker)
             (work_begining_time)(result_comment_id)(worker_payments_count)(next_payout)
             (created)(modified))
-
-        void modify(const tspec_data_t &that, bool limited = false) {
-            data.update(that, limited);
-            modified = TIMESTAMP_NOW;
-        }
 
         uint64_t primary_key() const { return id; }
         uint64_t foreign_key() const { return foreign_id; }

--- a/tests/golos.worker_tests.cpp
+++ b/tests/golos.worker_tests.cpp
@@ -136,9 +136,7 @@ public:
             ("proposal_id", proposal_id)
             ("tspec", mvo()
                 ("specification_cost", "5.000 APP")
-                ("specification_eta", 1)
                 ("development_cost", "5.000 APP")
-                ("development_eta", 1)
                 ("payments_count", 1)
                 ("payments_interval", 1))));
 
@@ -154,9 +152,7 @@ public:
             ("proposal_id", proposal_id)
             ("tspec", mvo()
                 ("specification_cost", "5.000 APP")
-                ("specification_eta", 1)
                 ("development_cost", "5.000 APP")
-                ("development_eta", 1)
                 ("payments_count", 2)
                 ("payments_interval", 1))));
 
@@ -176,32 +172,6 @@ public:
         // if technical specification application was upvoted, `tspec_deposit` should be deposited from the application fund
         BOOST_REQUIRE_EQUAL(worker.get_tspec(tspec_app_id)["deposit"].as<asset>(), tspec_deposit);
         BOOST_REQUIRE_EQUAL(worker.get_tspec_state(tspec_app_id), STATE_APPROVED);
-
-        /* ok,technical specification application has been choosen,
-        now technical specification application author should publish
-        a final technical specification */
-
-        BOOST_REQUIRE_EQUAL(worker.push_action(tspec_author, N(edittspec), mvo()
-            ("tspec_id", tspec_app_id)
-            ("tspec", mvo()
-                ("specification_cost", "10.000 APP")
-                ("specification_eta", 1)
-                ("development_cost", "10.000 APP")
-                ("development_eta", 1)
-                ("payments_count", 1)
-                ("payments_interval", 1))), wasm_assert_msg("cost can't be modified"));
-
-        BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_CHOSE);
-
-        ASSERT_SUCCESS(worker.push_action(tspec_author, N(edittspec), mvo()
-            ("tspec_id", tspec_app_id)
-            ("tspec", mvo()
-                ("specification_cost", "0.000 APP")
-                ("specification_eta", 1)
-                ("development_cost", "0.000 APP")
-                ("development_eta", 1)
-                ("payments_count", 1)
-                ("payments_interval", 1))));
 
         BOOST_REQUIRE_EQUAL(worker.get_proposal_state(proposal_id), STATE_TSPEC_CHOSE);
 
@@ -478,9 +448,7 @@ try
                 ("proposal_id", proposal_id)
                 ("tspec", mvo()
                     ("specification_cost", "1.000 APP")
-                    ("specification_eta", 1)
                     ("development_cost", "1.000 APP")
-                    ("development_eta", 1)
                     ("payments_count", 1)
                     ("payments_interval", 1));
             ASSERT_SUCCESS(worker.push_action(tspec_author, N(addtspec), tspec_app));
@@ -488,9 +456,7 @@ try
             auto tspec_row = worker.get_tspec(tspec_app_id);
             BOOST_REQUIRE_EQUAL(tspec_row["id"].as_int64(), tspec_app_id);
             BOOST_REQUIRE_EQUAL(tspec_row["data"]["specification_cost"].as<asset>().to_string(), tspec_app["tspec"]["specification_cost"]);
-            BOOST_REQUIRE_EQUAL(tspec_row["data"]["specification_eta"], tspec_app["tspec"]["specification_eta"]);
             BOOST_REQUIRE_EQUAL(tspec_row["data"]["development_cost"].as<asset>().to_string(), tspec_app["tspec"]["development_cost"]);
-            BOOST_REQUIRE_EQUAL(tspec_row["data"]["development_eta"], tspec_app["tspec"]["development_eta"]);
             BOOST_REQUIRE_EQUAL(tspec_row["data"]["payments_count"], tspec_app["tspec"]["payments_count"]);
             BOOST_REQUIRE_EQUAL(tspec_row["data"]["payments_interval"], tspec_app["tspec"]["payments_interval"]);
 
@@ -498,9 +464,7 @@ try
                 ("tspec_id", tspec_app_id)
                 ("tspec", mvo()
                     ("specification_cost", "2.000 APP")
-                    ("specification_eta", 2)
                     ("development_cost", "2.000 APP")
-                    ("development_eta", 2)
                     ("payments_count", 2)
                     ("payments_interval", 2))
                 ("tspec_text", "Technical specification")));
@@ -577,9 +541,7 @@ try
             ("proposal_id", proposal_id)
             ("tspec", mvo()
                 ("specification_cost", "1.000 APP")
-                ("specification_eta", 1)
                 ("development_cost", "1.000 APP")
-                ("development_eta", 1)
                 ("payments_count", 1)
                 ("payments_interval", 1));
 
@@ -695,9 +657,7 @@ try
         ("proposal_id", proposal_id)
         ("tspec", mvo()
             ("specification_cost", "5.000 APP")
-            ("specification_eta", 1)
             ("development_cost", "5.000 APP")
-            ("development_eta", 1)
             ("payments_count", payments_count)
             ("payments_interval", 1))
         ("worker", worker_account)));


### PR DESCRIPTION
Resolve #77:
- Removed eta from tspec.
- Removed ability to partially edit tspec after it approve.